### PR TITLE
feature: add explicit agent identity and per-port agent routing in static config

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ Current `v1` focus:
 
 - `cmd/gotunneld`: relay process for the VPS
 - `cmd/gotunnel`: local agent process
-- one persistent control connection from the local machine to the VPS
+- one persistent control connection per local machine to the VPS
 - fixed public TCP ports on the VPS
 - token authentication
+- explicit agent identity in static config
 - automatic reconnect loop
 - encrypted control plane by default
 
@@ -82,7 +83,7 @@ go build ./cmd/gotunnel ./cmd/gotunneld
 
 ## Quick start
 
-1. Copy the example configs and replace the token.
+1. Copy the example configs and replace the token and agent IDs.
 2. For a real deployment, point the relay config at your TLS certificate and key and use a `wss://` relay URL in the agent config.
 3. Start the relay on the VPS:
 
@@ -100,7 +101,8 @@ go build ./cmd/gotunnel ./cmd/gotunneld
 
 Example:
 
-- relay port `2222` named `ssh`
+- relay port `2222` named `ssh` routed to `home-mac:ssh`
+- local agent `home-mac`
 - local target `ssh -> 127.0.0.1:22`
 
 Then:
@@ -182,6 +184,9 @@ Fields:
 - `tls_key_file`: private key for the control connection
 - `allow_insecure`: only for local testing; allows plain `ws://`
 - `ports`: public TCP listeners exposed on the VPS
+- `ports[].name`: public listener name
+- `ports[].agent_id`: which named agent should receive traffic for that listener
+- `ports[].target_name`: which target on that agent should be opened
 
 ## Agent config
 
@@ -190,6 +195,7 @@ Example: [examples/agent.json](/Users/kai/Developer/utils/gotunnel/examples/agen
 Fields:
 
 - `relay_url`: `wss://.../connect` in normal use
+- `agent_id`: stable identity for this local machine or agent instance
 - `auth_token`: shared token that must match the relay config
 - `allow_insecure`: only for local testing with `ws://`
 - `targets`: local services reachable through the tunnel
@@ -198,10 +204,12 @@ Fields:
 
 Example SSH mapping:
 
-- relay port `0.0.0.0:2222` named `ssh`
-- agent target `ssh` mapped to `127.0.0.1:22`
+- relay port `0.0.0.0:2222` named `ssh` routed to agent `home-mac`
+- agent `home-mac` target `ssh` mapped to `127.0.0.1:22`
 
 With both binaries running, connecting to `vps:2222` reaches the local machine's SSH service through the tunnel.
+
+Different agents can expose the same target name, such as `ssh`, as long as each relay port mapping points to the intended `agent_id` explicitly.
 
 ## Current limitations
 
@@ -209,5 +217,6 @@ With both binaries running, connecting to `vps:2222` reaches the local machine's
 - no session preservation across reconnect
 - no multi-agent failover
 - no persistent control-plane state yet
+- no management API for dynamically registering or editing agents
 
 Those are deliberate `A`-phase omissions so the transport core can stay small and reliable first.

--- a/examples/agent.json
+++ b/examples/agent.json
@@ -1,5 +1,6 @@
 {
   "relay_url": "wss://example.com/connect",
+  "agent_id": "home-mac",
   "auth_token": "replace-me",
   "targets": [
     {

--- a/examples/relay.json
+++ b/examples/relay.json
@@ -8,15 +8,21 @@
   "ports": [
     {
       "name": "ssh",
-      "listen_addr": "0.0.0.0:2222"
+      "listen_addr": "0.0.0.0:2222",
+      "agent_id": "home-mac",
+      "target_name": "ssh"
     },
     {
       "name": "web",
-      "listen_addr": "0.0.0.0:8080"
+      "listen_addr": "0.0.0.0:8080",
+      "agent_id": "home-mac",
+      "target_name": "web"
     },
     {
       "name": "rdp",
-      "listen_addr": "0.0.0.0:3389"
+      "listen_addr": "0.0.0.0:3389",
+      "agent_id": "office-pc",
+      "target_name": "rdp"
     }
   ]
 }

--- a/internal/agent/client.go
+++ b/internal/agent/client.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log"
 	"net"
+	"strings"
 	"sync"
 	"time"
 
@@ -25,6 +26,7 @@ const (
 
 type Client struct {
 	cfg     config.AgentConfig
+	agentID string
 	targets map[string]string
 }
 
@@ -49,6 +51,7 @@ func NewClient(cfg config.AgentConfig) (*Client, error) {
 
 	return &Client{
 		cfg:     cfg,
+		agentID: cfg.AgentID,
 		targets: targets,
 	}, nil
 }
@@ -63,6 +66,10 @@ func (c *Client) Start(ctx context.Context) error {
 		}
 		if err != nil && errors.Is(err, errUnauthorized) {
 			log.Printf("gotunnel: relay rejected credentials")
+			return err
+		}
+		if err != nil && errors.Is(err, errDuplicateAgentID) {
+			log.Printf("gotunnel: duplicate agent id rejected by relay")
 			return err
 		}
 		if err != nil {
@@ -83,6 +90,7 @@ func (c *Client) Start(ctx context.Context) error {
 }
 
 var errUnauthorized = errors.New("unauthorized")
+var errDuplicateAgentID = errors.New("duplicate active agent id")
 
 func (c *Client) runOnce(ctx context.Context) error {
 	conn, _, err := websocket.DefaultDialer.DialContext(ctx, c.cfg.RelayURL, nil)
@@ -122,11 +130,29 @@ func (c *Client) runOnce(ctx context.Context) error {
 	for name := range c.targets {
 		targetNames = append(targetNames, name)
 	}
-	registerPayload, _ := json.Marshal(protocol.RegisterRequest{Targets: targetNames})
+	registerPayload, _ := json.Marshal(protocol.RegisterRequest{
+		AgentID: c.agentID,
+		Targets: targetNames,
+	})
 	if err := sess.write(protocol.Frame{Type: protocol.FrameRegister, Payload: registerPayload}); err != nil {
 		return err
 	}
-	log.Printf("gotunnel: registered %d target(s)", len(targetNames))
+
+	registerReply, err := readFrame(conn)
+	if err != nil {
+		return err
+	}
+	if registerReply.Type == protocol.FrameError {
+		msg := string(registerReply.Payload)
+		if strings.HasPrefix(msg, "duplicate active agent id:") {
+			return errDuplicateAgentID
+		}
+		return errors.New(msg)
+	}
+	if registerReply.Type != protocol.FrameRegisterOK {
+		return fmt.Errorf("unexpected register reply: %v", registerReply.Type)
+	}
+	log.Printf("gotunnel: registered agent %s with %d target(s)", c.agentID, len(targetNames))
 
 	for {
 		select {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,10 +19,13 @@ type RelayConfig struct {
 type PortMapping struct {
 	Name       string `json:"name"`
 	ListenAddr string `json:"listen_addr"`
+	AgentID    string `json:"agent_id"`
+	TargetName string `json:"target_name"`
 }
 
 type AgentConfig struct {
 	RelayURL      string          `json:"relay_url"`
+	AgentID       string          `json:"agent_id"`
 	AuthToken     string          `json:"auth_token"`
 	AllowInsecure bool            `json:"allow_insecure"`
 	Targets       []TargetMapping `json:"targets"`
@@ -69,6 +72,12 @@ func (c RelayConfig) Validate() error {
 		if _, err := net.ResolveTCPAddr("tcp", port.ListenAddr); err != nil {
 			return fmt.Errorf("invalid listen address for %s: %w", port.Name, err)
 		}
+		if port.AgentID == "" {
+			return fmt.Errorf("agent_id is required for port mapping %s", port.Name)
+		}
+		if port.TargetName == "" {
+			return fmt.Errorf("target_name is required for port mapping %s", port.Name)
+		}
 	}
 
 	return nil
@@ -87,6 +96,9 @@ func (c AgentConfig) Validate() error {
 	}
 	if parsed.Scheme == "ws" && !c.AllowInsecure {
 		return errors.New("plain ws relay URL requires allow_insecure to be true")
+	}
+	if c.AgentID == "" {
+		return errors.New("agent_id is required")
 	}
 	if c.AuthToken == "" {
 		return errors.New("auth token is required")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -17,6 +17,8 @@ func TestRelayConfigValidateAcceptsMinimalValidConfig(t *testing.T) {
 			{
 				Name:       "ssh",
 				ListenAddr: "127.0.0.1:0",
+				AgentID:    "mac-mini",
+				TargetName: "ssh",
 			},
 		},
 	}
@@ -32,8 +34,8 @@ func TestRelayConfigValidateRejectsDuplicatePortNames(t *testing.T) {
 		AuthTokens:    []string{"secret"},
 		AllowInsecure: true,
 		Ports: []config.PortMapping{
-			{Name: "ssh", ListenAddr: "127.0.0.1:0"},
-			{Name: "ssh", ListenAddr: "127.0.0.1:0"},
+			{Name: "ssh", ListenAddr: "127.0.0.1:0", AgentID: "mac-mini", TargetName: "ssh"},
+			{Name: "ssh", ListenAddr: "127.0.0.1:0", AgentID: "office-pc", TargetName: "ssh"},
 		},
 	}
 
@@ -45,6 +47,7 @@ func TestRelayConfigValidateRejectsDuplicatePortNames(t *testing.T) {
 func TestAgentConfigValidateRejectsUnknownTargetNames(t *testing.T) {
 	cfg := config.AgentConfig{
 		RelayURL:      "ws://127.0.0.1:443/connect",
+		AgentID:       "mac-mini",
 		AuthToken:     "secret",
 		AllowInsecure: true,
 		Targets: []config.TargetMapping{
@@ -61,6 +64,7 @@ func TestAgentConfigValidateRejectsUnknownTargetNames(t *testing.T) {
 func TestAgentConfigValidateRejectsPlainWSByDefault(t *testing.T) {
 	cfg := config.AgentConfig{
 		RelayURL:  "ws://127.0.0.1:443/connect",
+		AgentID:   "mac-mini",
 		AuthToken: "secret",
 		Targets: []config.TargetMapping{
 			{Name: "ssh", LocalAddr: "127.0.0.1:22"},
@@ -78,7 +82,7 @@ func TestRelayConfigValidateRejectsPartialTLSConfig(t *testing.T) {
 		AuthTokens:  []string{"secret"},
 		TLSCertFile: "/tmp/cert.pem",
 		Ports: []config.PortMapping{
-			{Name: "ssh", ListenAddr: "127.0.0.1:0"},
+			{Name: "ssh", ListenAddr: "127.0.0.1:0", AgentID: "mac-mini", TargetName: "ssh"},
 		},
 	}
 
@@ -94,7 +98,7 @@ func TestLoadRelayConfigFromJSONFile(t *testing.T) {
 		"auth_tokens": ["secret"],
 		"allow_insecure": true,
 		"ports": [
-			{"name": "ssh", "listen_addr": "127.0.0.1:0"}
+			{"name": "ssh", "listen_addr": "127.0.0.1:0", "agent_id": "mac-mini", "target_name": "ssh"}
 		]
 	}`
 
@@ -119,6 +123,7 @@ func TestLoadAgentConfigFromJSONFile(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "agent.json")
 	content := `{
 		"relay_url": "ws://127.0.0.1:8080/connect",
+		"agent_id": "mac-mini",
 		"auth_token": "secret",
 		"allow_insecure": true,
 		"targets": [
@@ -138,7 +143,40 @@ func TestLoadAgentConfigFromJSONFile(t *testing.T) {
 	if cfg.RelayURL != "ws://127.0.0.1:8080/connect" {
 		t.Fatalf("unexpected relay url: %s", cfg.RelayURL)
 	}
+	if cfg.AgentID != "mac-mini" {
+		t.Fatalf("unexpected agent id: %s", cfg.AgentID)
+	}
 	if len(cfg.Targets) != 1 || cfg.Targets[0].Name != "ssh" {
 		t.Fatalf("unexpected targets: %+v", cfg.Targets)
+	}
+}
+
+func TestAgentConfigValidateRejectsMissingAgentID(t *testing.T) {
+	cfg := config.AgentConfig{
+		RelayURL:      "ws://127.0.0.1:443/connect",
+		AuthToken:     "secret",
+		AllowInsecure: true,
+		Targets: []config.TargetMapping{
+			{Name: "ssh", LocalAddr: "127.0.0.1:22"},
+		},
+	}
+
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected missing agent id to fail validation")
+	}
+}
+
+func TestRelayConfigValidateRejectsMissingPortRouteFields(t *testing.T) {
+	cfg := config.RelayConfig{
+		ControlAddr:   "127.0.0.1:0",
+		AuthTokens:    []string{"secret"},
+		AllowInsecure: true,
+		Ports: []config.PortMapping{
+			{Name: "ssh", ListenAddr: "127.0.0.1:0"},
+		},
+	}
+
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected missing port route fields to fail validation")
 	}
 }

--- a/internal/e2e/tunnel_test.go
+++ b/internal/e2e/tunnel_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -29,6 +30,8 @@ func TestTunnelForwardsTCPTraffic(t *testing.T) {
 			{
 				Name:       "ssh",
 				ListenAddr: "127.0.0.1:0",
+				AgentID:    "mac-mini",
+				TargetName: "ssh",
 			},
 		},
 	}
@@ -46,6 +49,7 @@ func TestTunnelForwardsTCPTraffic(t *testing.T) {
 
 	agentCfg := config.AgentConfig{
 		RelayURL:      relayServer.ControlURL(),
+		AgentID:       "mac-mini",
 		AuthToken:     "secret",
 		AllowInsecure: true,
 		Targets: []config.TargetMapping{
@@ -107,6 +111,8 @@ func TestTunnelReconnectsAfterRelayRestart(t *testing.T) {
 			{
 				Name:       "ssh",
 				ListenAddr: publicAddr,
+				AgentID:    "mac-mini",
+				TargetName: "ssh",
 			},
 		},
 	}
@@ -125,6 +131,7 @@ func TestTunnelReconnectsAfterRelayRestart(t *testing.T) {
 
 	agentCfg := config.AgentConfig{
 		RelayURL:      relayServer.ControlURL(),
+		AgentID:       "mac-mini",
 		AuthToken:     "secret",
 		AllowInsecure: true,
 		Targets: []config.TargetMapping{
@@ -181,6 +188,8 @@ func TestTunnelFailsFastWhenTargetIsUnavailable(t *testing.T) {
 			{
 				Name:       "ssh",
 				ListenAddr: "127.0.0.1:0",
+				AgentID:    "mac-mini",
+				TargetName: "ssh",
 			},
 		},
 	}
@@ -198,6 +207,7 @@ func TestTunnelFailsFastWhenTargetIsUnavailable(t *testing.T) {
 
 	agentCfg := config.AgentConfig{
 		RelayURL:      relayServer.ControlURL(),
+		AgentID:       "mac-mini",
 		AuthToken:     "secret",
 		AllowInsecure: true,
 		Targets: []config.TargetMapping{
@@ -248,8 +258,8 @@ func TestTunnelForwardsMultiplePublicPorts(t *testing.T) {
 		AuthTokens:    []string{"secret"},
 		AllowInsecure: true,
 		Ports: []config.PortMapping{
-			{Name: "ssh", ListenAddr: "127.0.0.1:0"},
-			{Name: "web", ListenAddr: "127.0.0.1:0"},
+			{Name: "ssh", ListenAddr: "127.0.0.1:0", AgentID: "mac-mini", TargetName: "ssh"},
+			{Name: "web", ListenAddr: "127.0.0.1:0", AgentID: "mac-mini", TargetName: "web"},
 		},
 	}
 
@@ -266,6 +276,7 @@ func TestTunnelForwardsMultiplePublicPorts(t *testing.T) {
 
 	agentCfg := config.AgentConfig{
 		RelayURL:      relayServer.ControlURL(),
+		AgentID:       "mac-mini",
 		AuthToken:     "secret",
 		AllowInsecure: true,
 		Targets: []config.TargetMapping{
@@ -287,6 +298,155 @@ func TestTunnelForwardsMultiplePublicPorts(t *testing.T) {
 
 	assertTunnelEcho(t, waitForPublicAddr(t, relayServer, "ssh"), "ssh")
 	assertTunnelEcho(t, waitForPublicAddr(t, relayServer, "web"), "web")
+}
+
+func TestTunnelRoutesOverlappingTargetNamesToTheConfiguredAgent(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	relayCfg := config.RelayConfig{
+		ControlAddr:   "127.0.0.1:0",
+		AuthTokens:    []string{"secret"},
+		AllowInsecure: true,
+		Ports: []config.PortMapping{
+			{Name: "mac-ssh", ListenAddr: "127.0.0.1:0", AgentID: "mac-mini", TargetName: "ssh"},
+			{Name: "office-ssh", ListenAddr: "127.0.0.1:0", AgentID: "office-pc", TargetName: "ssh"},
+		},
+	}
+
+	relayServer, err := relay.NewServer(relayCfg)
+	if err != nil {
+		t.Fatalf("new relay server: %v", err)
+	}
+
+	go func() {
+		if err := relayServer.Start(ctx); err != nil && ctx.Err() == nil {
+			t.Errorf("relay start: %v", err)
+		}
+	}()
+
+	macClient, err := agent.NewClient(config.AgentConfig{
+		RelayURL:      relayServer.ControlURL(),
+		AgentID:       "mac-mini",
+		AuthToken:     "secret",
+		AllowInsecure: true,
+		Targets: []config.TargetMapping{
+			{Name: "ssh", LocalAddr: startTaggedEchoServer(t, "mac:")},
+		},
+	})
+	if err != nil {
+		t.Fatalf("new mac agent client: %v", err)
+	}
+
+	officeClient, err := agent.NewClient(config.AgentConfig{
+		RelayURL:      relayServer.ControlURL(),
+		AgentID:       "office-pc",
+		AuthToken:     "secret",
+		AllowInsecure: true,
+		Targets: []config.TargetMapping{
+			{Name: "ssh", LocalAddr: startTaggedEchoServer(t, "office:")},
+		},
+	})
+	if err != nil {
+		t.Fatalf("new office agent client: %v", err)
+	}
+
+	go func() {
+		if err := macClient.Start(ctx); err != nil && ctx.Err() == nil {
+			t.Errorf("mac agent start: %v", err)
+		}
+	}()
+	go func() {
+		if err := officeClient.Start(ctx); err != nil && ctx.Err() == nil {
+			t.Errorf("office agent start: %v", err)
+		}
+	}()
+
+	assertTunnelReply(t, waitForPublicAddr(t, relayServer, "mac-ssh"), "ping", "mac:ping")
+	assertTunnelReply(t, waitForPublicAddr(t, relayServer, "office-ssh"), "ping", "office:ping")
+}
+
+func TestTunnelRejectsDuplicateActiveAgentID(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	relayCfg := config.RelayConfig{
+		ControlAddr:   "127.0.0.1:0",
+		AuthTokens:    []string{"secret"},
+		AllowInsecure: true,
+		Ports: []config.PortMapping{
+			{Name: "ssh", ListenAddr: "127.0.0.1:0", AgentID: "mac-mini", TargetName: "ssh"},
+		},
+	}
+
+	relayServer, err := relay.NewServer(relayCfg)
+	if err != nil {
+		t.Fatalf("new relay server: %v", err)
+	}
+
+	go func() {
+		if err := relayServer.Start(ctx); err != nil && ctx.Err() == nil {
+			t.Errorf("relay start: %v", err)
+		}
+	}()
+
+	firstClient, err := agent.NewClient(config.AgentConfig{
+		RelayURL:      relayServer.ControlURL(),
+		AgentID:       "mac-mini",
+		AuthToken:     "secret",
+		AllowInsecure: true,
+		Targets: []config.TargetMapping{
+			{Name: "ssh", LocalAddr: startTaggedEchoServer(t, "first:")},
+		},
+	})
+	if err != nil {
+		t.Fatalf("new first agent client: %v", err)
+	}
+
+	go func() {
+		if err := firstClient.Start(ctx); err != nil && ctx.Err() == nil {
+			t.Errorf("first agent start: %v", err)
+		}
+	}()
+
+	publicAddr := waitForPublicAddr(t, relayServer, "ssh")
+	assertTunnelReply(t, publicAddr, "ping", "first:ping")
+
+	duplicateCtx, stopDuplicate := context.WithCancel(ctx)
+	defer stopDuplicate()
+
+	duplicateClient, err := agent.NewClient(config.AgentConfig{
+		RelayURL:      relayServer.ControlURL(),
+		AgentID:       "mac-mini",
+		AuthToken:     "secret",
+		AllowInsecure: true,
+		Targets: []config.TargetMapping{
+			{Name: "ssh", LocalAddr: startTaggedEchoServer(t, "second:")},
+		},
+	})
+	if err != nil {
+		t.Fatalf("new duplicate agent client: %v", err)
+	}
+
+	duplicateErrCh := make(chan error, 1)
+	go func() {
+		duplicateErrCh <- duplicateClient.Start(duplicateCtx)
+	}()
+
+	select {
+	case err := <-duplicateErrCh:
+		if err == nil || !strings.Contains(err.Error(), "duplicate active agent id") {
+			t.Fatalf("expected duplicate agent rejection, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("duplicate agent was not rejected in time")
+	}
+
+	assertTunnelReply(t, publicAddr, "ping", "first:ping")
 }
 
 func startEchoServer(t *testing.T) string {
@@ -318,6 +478,43 @@ func startEchoServer(t *testing.T) string {
 	return ln.Addr().String()
 }
 
+func startTaggedEchoServer(t *testing.T, prefix string) string {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen tagged echo: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_ = ln.Close()
+	})
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+
+			go func(c net.Conn) {
+				defer c.Close()
+
+				buf := make([]byte, 1024)
+				n, err := c.Read(buf)
+				if n > 0 {
+					_, _ = c.Write([]byte(prefix + string(buf[:n])))
+				}
+				if err != nil {
+					return
+				}
+			}(conn)
+		}
+	}()
+
+	return ln.Addr().String()
+}
+
 func reserveTCPAddress(t *testing.T) string {
 	t.Helper()
 
@@ -333,6 +530,12 @@ func reserveTCPAddress(t *testing.T) string {
 func assertTunnelEcho(t *testing.T, publicAddr, payload string) {
 	t.Helper()
 
+	assertTunnelReply(t, publicAddr, payload, payload)
+}
+
+func assertTunnelReply(t *testing.T, publicAddr, payload, want string) {
+	t.Helper()
+
 	conn, err := net.DialTimeout("tcp", publicAddr, 2*time.Second)
 	if err != nil {
 		t.Fatalf("dial public addr: %v", err)
@@ -343,13 +546,13 @@ func assertTunnelEcho(t *testing.T, publicAddr, payload string) {
 		t.Fatalf("write public conn: %v", err)
 	}
 
-	reply := make([]byte, len(payload))
+	reply := make([]byte, len(want))
 	if _, err := io.ReadFull(conn, reply); err != nil {
 		t.Fatalf("read public conn: %v", err)
 	}
 
-	if string(reply) != payload {
-		t.Fatalf("unexpected reply: got %q want %q", string(reply), payload)
+	if string(reply) != want {
+		t.Fatalf("unexpected reply: got %q want %q", string(reply), want)
 	}
 }
 

--- a/internal/protocol/frame.go
+++ b/internal/protocol/frame.go
@@ -11,6 +11,7 @@ const (
 	FrameAuth FrameType = iota + 1
 	FrameAuthOK
 	FrameRegister
+	FrameRegisterOK
 	FrameOpen
 	FrameOpenResult
 	FrameData

--- a/internal/protocol/message.go
+++ b/internal/protocol/message.go
@@ -5,6 +5,7 @@ type AuthRequest struct {
 }
 
 type RegisterRequest struct {
+	AgentID string   `json:"agent_id"`
 	Targets []string `json:"targets"`
 }
 

--- a/internal/relay/server.go
+++ b/internal/relay/server.go
@@ -25,21 +25,25 @@ const (
 	pingPeriod = 10 * time.Second
 )
 
+const duplicateAgentErrorPrefix = "duplicate active agent id:"
+
 type Server struct {
 	cfg             config.RelayConfig
 	controlListener net.Listener
 	publicListeners map[string]net.Listener
+	publicRoutes    map[string]config.PortMapping
 
 	httpServer *http.Server
 
-	mu      sync.RWMutex
-	session *session
+	mu       sync.RWMutex
+	sessions map[string]*session
 }
 
 type session struct {
 	conn *websocket.Conn
 
 	writerMu sync.Mutex
+	agentID  string
 	targets  map[string]struct{}
 
 	streamMu     sync.RWMutex
@@ -59,6 +63,7 @@ func NewServer(cfg config.RelayConfig) (*Server, error) {
 	}
 
 	publicListeners := make(map[string]net.Listener, len(cfg.Ports))
+	publicRoutes := make(map[string]config.PortMapping, len(cfg.Ports))
 	for _, mapping := range cfg.Ports {
 		ln, err := net.Listen("tcp", mapping.ListenAddr)
 		if err != nil {
@@ -69,12 +74,15 @@ func NewServer(cfg config.RelayConfig) (*Server, error) {
 			return nil, fmt.Errorf("listen public %s: %w", mapping.Name, err)
 		}
 		publicListeners[mapping.Name] = ln
+		publicRoutes[mapping.Name] = mapping
 	}
 
 	s := &Server{
 		cfg:             cfg,
 		controlListener: controlListener,
 		publicListeners: publicListeners,
+		publicRoutes:    publicRoutes,
+		sessions:        make(map[string]*session),
 	}
 
 	mux := http.NewServeMux()
@@ -153,15 +161,24 @@ func (s *Server) handleControl(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s.replaceSession(sess)
-	log.Printf("gotunneld: agent connected with %d target(s)", len(sess.targets))
+	if err := s.addSession(sess); err != nil {
+		_ = sess.write(protocol.Frame{Type: protocol.FrameError, Payload: []byte(err.Error())})
+		_ = conn.Close()
+		return
+	}
+	if err := sess.write(protocol.Frame{Type: protocol.FrameRegisterOK}); err != nil {
+		s.clearSession(sess)
+		sess.close()
+		return
+	}
+	log.Printf("gotunneld: agent %s connected with %d target(s)", sess.agentID, len(sess.targets))
 	stopHeartbeat := make(chan struct{})
 	go sess.heartbeat(stopHeartbeat)
 	defer func() {
 		close(stopHeartbeat)
 		s.clearSession(sess)
 		sess.close()
-		log.Printf("gotunneld: agent session closed")
+		log.Printf("gotunneld: agent %s session closed", sess.agentID)
 	}()
 
 	if err := s.readLoop(sess); err != nil && !errors.Is(err, net.ErrClosed) {
@@ -211,6 +228,7 @@ func (s *Server) authenticate(conn *websocket.Conn) (*session, error) {
 
 	return &session{
 		conn:        conn,
+		agentID:     register.AgentID,
 		targets:     targets,
 		streams:     make(map[uint32]net.Conn),
 		openResults: make(map[uint32]chan protocol.OpenResult),
@@ -265,6 +283,7 @@ func (s *Server) readLoop(sess *session) error {
 }
 
 func (s *Server) acceptPublic(ctx context.Context, name string, ln net.Listener) {
+	route := s.publicRoutes[name]
 	for {
 		conn, err := ln.Accept()
 		if err != nil {
@@ -273,12 +292,12 @@ func (s *Server) acceptPublic(ctx context.Context, name string, ln net.Listener)
 			}
 			continue
 		}
-		go s.handlePublicConn(ctx, name, conn)
+		go s.handlePublicConn(ctx, route, conn)
 	}
 }
 
-func (s *Server) handlePublicConn(ctx context.Context, name string, publicConn net.Conn) {
-	sess := s.waitForSessionFor(ctx, name, 3*time.Second)
+func (s *Server) handlePublicConn(ctx context.Context, route config.PortMapping, publicConn net.Conn) {
+	sess := s.waitForSessionFor(ctx, route.AgentID, route.TargetName, 3*time.Second)
 	if sess == nil {
 		_ = publicConn.Close()
 		return
@@ -301,7 +320,7 @@ func (s *Server) handlePublicConn(ctx context.Context, name string, publicConn n
 		_ = publicConn.Close()
 	}()
 
-	payload, _ := json.Marshal(protocol.OpenRequest{Target: name})
+	payload, _ := json.Marshal(protocol.OpenRequest{Target: route.TargetName})
 	if err := sess.write(protocol.Frame{Type: protocol.FrameOpen, StreamID: streamID, Payload: payload}); err != nil {
 		return
 	}
@@ -340,39 +359,41 @@ func (s *Server) isAllowedToken(token string) bool {
 	return false
 }
 
-func (s *Server) replaceSession(sess *session) {
+func (s *Server) addSession(sess *session) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.session != nil {
-		s.session.close()
+	if _, exists := s.sessions[sess.agentID]; exists {
+		return fmt.Errorf("%s %s", duplicateAgentErrorPrefix, sess.agentID)
 	}
-	s.session = sess
+	s.sessions[sess.agentID] = sess
+	return nil
 }
 
 func (s *Server) clearSession(sess *session) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.session == sess {
-		s.session = nil
+	if current := s.sessions[sess.agentID]; current == sess {
+		delete(s.sessions, sess.agentID)
 	}
 }
 
-func (s *Server) currentSessionFor(name string) *session {
+func (s *Server) currentSessionFor(agentID, targetName string) *session {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	if s.session == nil {
+	sess := s.sessions[agentID]
+	if sess == nil {
 		return nil
 	}
-	if _, ok := s.session.targets[name]; !ok {
+	if _, ok := sess.targets[targetName]; !ok {
 		return nil
 	}
-	return s.session
+	return sess
 }
 
-func (s *Server) waitForSessionFor(ctx context.Context, name string, timeout time.Duration) *session {
+func (s *Server) waitForSessionFor(ctx context.Context, agentID, targetName string, timeout time.Duration) *session {
 	deadline := time.Now().Add(timeout)
 	for {
-		if sess := s.currentSessionFor(name); sess != nil {
+		if sess := s.currentSessionFor(agentID, targetName); sess != nil {
 			return sess
 		}
 		if ctx.Err() != nil || time.Now().After(deadline) {
@@ -385,9 +406,9 @@ func (s *Server) waitForSessionFor(ctx context.Context, name string, timeout tim
 func (s *Server) closeSession() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.session != nil {
-		s.session.close()
-		s.session = nil
+	for agentID, sess := range s.sessions {
+		sess.close()
+		delete(s.sessions, agentID)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add explicit agent identity to agent config, relay config, and the register protocol
- Route public listeners to explicit (agent_id, target_name) pairs and track active relay sessions by agent identity
- Extend end-to-end coverage and docs for multi-agent routing and duplicate active-agent rejection

## Linked Issue

Closes #4

## Closeout Checklist

- [x] Re-read the linked issue after implementation
- [x] Reconciled the canonical plan comment checklist against the shipped code
- [x] No unchecked implementation checklist items remain in the issue body or canonical plan comment
- [x] This PR inherits the linked issue milestone when one exists

## Checklist Audit

- Issue body unchecked items: 0
- Canonical plan comment blocking unchecked items: 0
- Canonical plan comment non-blocking unchecked items: 0
- Canonical plan comment: https://github.com/grepug/gotunnel/issues/4#issuecomment-4288799157

## Validation

- go test ./...
- go test -race ./...
- go build ./cmd/gotunnel ./cmd/gotunneld
