### PR TITLE
feature: add per-agent credentials for named-agent ownership

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ go build ./cmd/gotunnel ./cmd/gotunneld
 
 ## Quick start
 
-1. Copy the example configs and replace the token and agent IDs.
+1. Copy the example configs and replace the per-agent credentials and agent IDs.
 2. For a real deployment, point the relay config at your TLS certificate and key and use a `wss://` relay URL in the agent config.
 3. Start the relay on the VPS:
 
@@ -179,7 +179,9 @@ Example: [examples/relay.json](/Users/kai/Developer/utils/gotunnel/examples/rela
 Fields:
 
 - `control_addr`: relay control listener
-- `auth_tokens`: accepted agent tokens
+- `agents`: relay-side credentials for each named agent
+- `agents[].agent_id`: named agent that is allowed to connect
+- `agents[].auth_token`: credential accepted only for that named agent
 - `tls_cert_file`: certificate for the control connection
 - `tls_key_file`: private key for the control connection
 - `allow_insecure`: only for local testing; allows plain `ws://`
@@ -196,7 +198,7 @@ Fields:
 
 - `relay_url`: `wss://.../connect` in normal use
 - `agent_id`: stable identity for this local machine or agent instance
-- `auth_token`: shared token that must match the relay config
+- `auth_token`: credential that must match the relay entry for this exact `agent_id`
 - `allow_insecure`: only for local testing with `ws://`
 - `targets`: local services reachable through the tunnel
 
@@ -218,5 +220,6 @@ Different agents can expose the same target name, such as `ssh`, as long as each
 - no multi-agent failover
 - no persistent control-plane state yet
 - no management API for dynamically registering or editing agents
+- no persisted control-plane registrations yet
 
 Those are deliberate `A`-phase omissions so the transport core can stay small and reliable first.

--- a/examples/agent.json
+++ b/examples/agent.json
@@ -1,7 +1,7 @@
 {
   "relay_url": "wss://example.com/connect",
   "agent_id": "home-mac",
-  "auth_token": "replace-me",
+  "auth_token": "replace-me-home-mac",
   "targets": [
     {
       "name": "ssh",

--- a/examples/relay.json
+++ b/examples/relay.json
@@ -1,7 +1,14 @@
 {
   "control_addr": "0.0.0.0:443",
-  "auth_tokens": [
-    "replace-me"
+  "agents": [
+    {
+      "agent_id": "home-mac",
+      "auth_token": "replace-me-home-mac"
+    },
+    {
+      "agent_id": "office-pc",
+      "auth_token": "replace-me-office-pc"
+    }
   ],
   "tls_cert_file": "/etc/letsencrypt/live/example.com/fullchain.pem",
   "tls_key_file": "/etc/letsencrypt/live/example.com/privkey.pem",

--- a/internal/agent/client.go
+++ b/internal/agent/client.go
@@ -110,7 +110,7 @@ func (c *Client) runOnce(ctx context.Context) error {
 	go sess.heartbeat(stopHeartbeat)
 	defer close(stopHeartbeat)
 
-	authPayload, _ := json.Marshal(protocol.AuthRequest{Token: c.cfg.AuthToken})
+	authPayload, _ := json.Marshal(protocol.AuthRequest{AgentID: c.agentID, Token: c.cfg.AuthToken})
 	if err := sess.write(protocol.Frame{Type: protocol.FrameAuth, Payload: authPayload}); err != nil {
 		return err
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,11 +9,16 @@ import (
 
 type RelayConfig struct {
 	ControlAddr   string        `json:"control_addr"`
-	AuthTokens    []string      `json:"auth_tokens"`
+	Agents        []AgentAuth   `json:"agents"`
 	TLSCertFile   string        `json:"tls_cert_file"`
 	TLSKeyFile    string        `json:"tls_key_file"`
 	AllowInsecure bool          `json:"allow_insecure"`
 	Ports         []PortMapping `json:"ports"`
+}
+
+type AgentAuth struct {
+	AgentID   string `json:"agent_id"`
+	AuthToken string `json:"auth_token"`
 }
 
 type PortMapping struct {
@@ -43,8 +48,8 @@ func (c RelayConfig) Validate() error {
 	if _, err := net.ResolveTCPAddr("tcp", c.ControlAddr); err != nil {
 		return fmt.Errorf("invalid control address: %w", err)
 	}
-	if len(c.AuthTokens) == 0 {
-		return errors.New("at least one auth token is required")
+	if len(c.Agents) == 0 {
+		return errors.New("at least one agent credential is required")
 	}
 	if (c.TLSCertFile == "") != (c.TLSKeyFile == "") {
 		return errors.New("tls_cert_file and tls_key_file must be set together")
@@ -54,6 +59,20 @@ func (c RelayConfig) Validate() error {
 	}
 	if len(c.Ports) == 0 {
 		return errors.New("at least one port mapping is required")
+	}
+
+	knownAgents := make(map[string]struct{}, len(c.Agents))
+	for _, agent := range c.Agents {
+		if agent.AgentID == "" {
+			return errors.New("agent_id is required for relay agent credentials")
+		}
+		if _, exists := knownAgents[agent.AgentID]; exists {
+			return fmt.Errorf("duplicate relay agent id: %s", agent.AgentID)
+		}
+		knownAgents[agent.AgentID] = struct{}{}
+		if agent.AuthToken == "" {
+			return fmt.Errorf("auth_token is required for relay agent %s", agent.AgentID)
+		}
 	}
 
 	seen := make(map[string]struct{}, len(c.Ports))
@@ -74,6 +93,9 @@ func (c RelayConfig) Validate() error {
 		}
 		if port.AgentID == "" {
 			return fmt.Errorf("agent_id is required for port mapping %s", port.Name)
+		}
+		if _, ok := knownAgents[port.AgentID]; !ok {
+			return fmt.Errorf("unknown agent_id %s for port mapping %s", port.AgentID, port.Name)
 		}
 		if port.TargetName == "" {
 			return fmt.Errorf("target_name is required for port mapping %s", port.Name)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -11,7 +11,7 @@ import (
 func TestRelayConfigValidateAcceptsMinimalValidConfig(t *testing.T) {
 	cfg := config.RelayConfig{
 		ControlAddr:   "127.0.0.1:0",
-		AuthTokens:    []string{"secret"},
+		Agents:        []config.AgentAuth{{AgentID: "mac-mini", AuthToken: "secret"}},
 		AllowInsecure: true,
 		Ports: []config.PortMapping{
 			{
@@ -30,8 +30,11 @@ func TestRelayConfigValidateAcceptsMinimalValidConfig(t *testing.T) {
 
 func TestRelayConfigValidateRejectsDuplicatePortNames(t *testing.T) {
 	cfg := config.RelayConfig{
-		ControlAddr:   "127.0.0.1:0",
-		AuthTokens:    []string{"secret"},
+		ControlAddr: "127.0.0.1:0",
+		Agents: []config.AgentAuth{
+			{AgentID: "mac-mini", AuthToken: "secret"},
+			{AgentID: "office-pc", AuthToken: "office-secret"},
+		},
 		AllowInsecure: true,
 		Ports: []config.PortMapping{
 			{Name: "ssh", ListenAddr: "127.0.0.1:0", AgentID: "mac-mini", TargetName: "ssh"},
@@ -79,7 +82,7 @@ func TestAgentConfigValidateRejectsPlainWSByDefault(t *testing.T) {
 func TestRelayConfigValidateRejectsPartialTLSConfig(t *testing.T) {
 	cfg := config.RelayConfig{
 		ControlAddr: "127.0.0.1:0",
-		AuthTokens:  []string{"secret"},
+		Agents:      []config.AgentAuth{{AgentID: "mac-mini", AuthToken: "secret"}},
 		TLSCertFile: "/tmp/cert.pem",
 		Ports: []config.PortMapping{
 			{Name: "ssh", ListenAddr: "127.0.0.1:0", AgentID: "mac-mini", TargetName: "ssh"},
@@ -95,7 +98,9 @@ func TestLoadRelayConfigFromJSONFile(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "relay.json")
 	content := `{
 		"control_addr": "127.0.0.1:0",
-		"auth_tokens": ["secret"],
+		"agents": [
+			{"agent_id": "mac-mini", "auth_token": "secret"}
+		],
 		"allow_insecure": true,
 		"ports": [
 			{"name": "ssh", "listen_addr": "127.0.0.1:0", "agent_id": "mac-mini", "target_name": "ssh"}
@@ -169,7 +174,7 @@ func TestAgentConfigValidateRejectsMissingAgentID(t *testing.T) {
 func TestRelayConfigValidateRejectsMissingPortRouteFields(t *testing.T) {
 	cfg := config.RelayConfig{
 		ControlAddr:   "127.0.0.1:0",
-		AuthTokens:    []string{"secret"},
+		Agents:        []config.AgentAuth{{AgentID: "mac-mini", AuthToken: "secret"}},
 		AllowInsecure: true,
 		Ports: []config.PortMapping{
 			{Name: "ssh", ListenAddr: "127.0.0.1:0"},
@@ -178,5 +183,37 @@ func TestRelayConfigValidateRejectsMissingPortRouteFields(t *testing.T) {
 
 	if err := cfg.Validate(); err == nil {
 		t.Fatal("expected missing port route fields to fail validation")
+	}
+}
+
+func TestRelayConfigValidateRejectsMissingAgents(t *testing.T) {
+	cfg := config.RelayConfig{
+		ControlAddr:   "127.0.0.1:0",
+		AllowInsecure: true,
+		Ports: []config.PortMapping{
+			{Name: "ssh", ListenAddr: "127.0.0.1:0", AgentID: "mac-mini", TargetName: "ssh"},
+		},
+	}
+
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected missing agents to fail validation")
+	}
+}
+
+func TestRelayConfigValidateRejectsDuplicateAgentIDs(t *testing.T) {
+	cfg := config.RelayConfig{
+		ControlAddr: "127.0.0.1:0",
+		Agents: []config.AgentAuth{
+			{AgentID: "mac-mini", AuthToken: "secret"},
+			{AgentID: "mac-mini", AuthToken: "other-secret"},
+		},
+		AllowInsecure: true,
+		Ports: []config.PortMapping{
+			{Name: "ssh", ListenAddr: "127.0.0.1:0", AgentID: "mac-mini", TargetName: "ssh"},
+		},
+	}
+
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected duplicate agent ids to fail validation")
 	}
 }

--- a/internal/e2e/tunnel_test.go
+++ b/internal/e2e/tunnel_test.go
@@ -24,7 +24,7 @@ func TestTunnelForwardsTCPTraffic(t *testing.T) {
 
 	relayCfg := config.RelayConfig{
 		ControlAddr:   "127.0.0.1:0",
-		AuthTokens:    []string{"secret"},
+		Agents:        []config.AgentAuth{{AgentID: "mac-mini", AuthToken: "secret"}},
 		AllowInsecure: true,
 		Ports: []config.PortMapping{
 			{
@@ -105,7 +105,7 @@ func TestTunnelReconnectsAfterRelayRestart(t *testing.T) {
 
 	relayCfg := config.RelayConfig{
 		ControlAddr:   controlAddr,
-		AuthTokens:    []string{"secret"},
+		Agents:        []config.AgentAuth{{AgentID: "mac-mini", AuthToken: "secret"}},
 		AllowInsecure: true,
 		Ports: []config.PortMapping{
 			{
@@ -182,7 +182,7 @@ func TestTunnelFailsFastWhenTargetIsUnavailable(t *testing.T) {
 
 	relayCfg := config.RelayConfig{
 		ControlAddr:   "127.0.0.1:0",
-		AuthTokens:    []string{"secret"},
+		Agents:        []config.AgentAuth{{AgentID: "mac-mini", AuthToken: "secret"}},
 		AllowInsecure: true,
 		Ports: []config.PortMapping{
 			{
@@ -255,7 +255,7 @@ func TestTunnelForwardsMultiplePublicPorts(t *testing.T) {
 
 	relayCfg := config.RelayConfig{
 		ControlAddr:   "127.0.0.1:0",
-		AuthTokens:    []string{"secret"},
+		Agents:        []config.AgentAuth{{AgentID: "mac-mini", AuthToken: "secret"}},
 		AllowInsecure: true,
 		Ports: []config.PortMapping{
 			{Name: "ssh", ListenAddr: "127.0.0.1:0", AgentID: "mac-mini", TargetName: "ssh"},
@@ -307,8 +307,11 @@ func TestTunnelRoutesOverlappingTargetNamesToTheConfiguredAgent(t *testing.T) {
 	defer cancel()
 
 	relayCfg := config.RelayConfig{
-		ControlAddr:   "127.0.0.1:0",
-		AuthTokens:    []string{"secret"},
+		ControlAddr: "127.0.0.1:0",
+		Agents: []config.AgentAuth{
+			{AgentID: "mac-mini", AuthToken: "secret"},
+			{AgentID: "office-pc", AuthToken: "office-secret"},
+		},
 		AllowInsecure: true,
 		Ports: []config.PortMapping{
 			{Name: "mac-ssh", ListenAddr: "127.0.0.1:0", AgentID: "mac-mini", TargetName: "ssh"},
@@ -343,7 +346,7 @@ func TestTunnelRoutesOverlappingTargetNamesToTheConfiguredAgent(t *testing.T) {
 	officeClient, err := agent.NewClient(config.AgentConfig{
 		RelayURL:      relayServer.ControlURL(),
 		AgentID:       "office-pc",
-		AuthToken:     "secret",
+		AuthToken:     "office-secret",
 		AllowInsecure: true,
 		Targets: []config.TargetMapping{
 			{Name: "ssh", LocalAddr: startTaggedEchoServer(t, "office:")},
@@ -376,7 +379,7 @@ func TestTunnelRejectsDuplicateActiveAgentID(t *testing.T) {
 
 	relayCfg := config.RelayConfig{
 		ControlAddr:   "127.0.0.1:0",
-		AuthTokens:    []string{"secret"},
+		Agents:        []config.AgentAuth{{AgentID: "mac-mini", AuthToken: "secret"}},
 		AllowInsecure: true,
 		Ports: []config.PortMapping{
 			{Name: "ssh", ListenAddr: "127.0.0.1:0", AgentID: "mac-mini", TargetName: "ssh"},
@@ -447,6 +450,175 @@ func TestTunnelRejectsDuplicateActiveAgentID(t *testing.T) {
 	}
 
 	assertTunnelReply(t, publicAddr, "ping", "first:ping")
+}
+
+func TestTunnelRejectsWrongCredentialForNamedAgent(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	relayCfg := config.RelayConfig{
+		ControlAddr: "127.0.0.1:0",
+		Agents: []config.AgentAuth{
+			{AgentID: "mac-mini", AuthToken: "secret"},
+		},
+		AllowInsecure: true,
+		Ports: []config.PortMapping{
+			{Name: "ssh", ListenAddr: "127.0.0.1:0", AgentID: "mac-mini", TargetName: "ssh"},
+		},
+	}
+
+	relayServer, err := relay.NewServer(relayCfg)
+	if err != nil {
+		t.Fatalf("new relay server: %v", err)
+	}
+
+	go func() {
+		if err := relayServer.Start(ctx); err != nil && ctx.Err() == nil {
+			t.Errorf("relay start: %v", err)
+		}
+	}()
+
+	badClient, err := agent.NewClient(config.AgentConfig{
+		RelayURL:      relayServer.ControlURL(),
+		AgentID:       "mac-mini",
+		AuthToken:     "wrong-secret",
+		AllowInsecure: true,
+		Targets: []config.TargetMapping{
+			{Name: "ssh", LocalAddr: startTaggedEchoServer(t, "bad:")},
+		},
+	})
+	if err != nil {
+		t.Fatalf("new bad agent client: %v", err)
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- badClient.Start(ctx)
+	}()
+
+	select {
+	case err := <-errCh:
+		if err == nil || !strings.Contains(err.Error(), "unauthorized") {
+			t.Fatalf("expected unauthorized error, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("wrong-credential agent was not rejected in time")
+	}
+}
+
+func TestTunnelRejectsUnknownNamedAgent(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	relayCfg := config.RelayConfig{
+		ControlAddr: "127.0.0.1:0",
+		Agents: []config.AgentAuth{
+			{AgentID: "mac-mini", AuthToken: "secret"},
+		},
+		AllowInsecure: true,
+		Ports: []config.PortMapping{
+			{Name: "ssh", ListenAddr: "127.0.0.1:0", AgentID: "mac-mini", TargetName: "ssh"},
+		},
+	}
+
+	relayServer, err := relay.NewServer(relayCfg)
+	if err != nil {
+		t.Fatalf("new relay server: %v", err)
+	}
+
+	go func() {
+		if err := relayServer.Start(ctx); err != nil && ctx.Err() == nil {
+			t.Errorf("relay start: %v", err)
+		}
+	}()
+
+	unknownClient, err := agent.NewClient(config.AgentConfig{
+		RelayURL:      relayServer.ControlURL(),
+		AgentID:       "unknown-agent",
+		AuthToken:     "secret",
+		AllowInsecure: true,
+		Targets: []config.TargetMapping{
+			{Name: "ssh", LocalAddr: startTaggedEchoServer(t, "bad:")},
+		},
+	})
+	if err != nil {
+		t.Fatalf("new unknown agent client: %v", err)
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- unknownClient.Start(ctx)
+	}()
+
+	select {
+	case err := <-errCh:
+		if err == nil || !strings.Contains(err.Error(), "unauthorized") {
+			t.Fatalf("expected unauthorized error, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("unknown agent was not rejected in time")
+	}
+}
+
+func TestTunnelRejectsCredentialForDifferentNamedAgent(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	relayCfg := config.RelayConfig{
+		ControlAddr: "127.0.0.1:0",
+		Agents: []config.AgentAuth{
+			{AgentID: "mac-mini", AuthToken: "secret"},
+			{AgentID: "office-pc", AuthToken: "office-secret"},
+		},
+		AllowInsecure: true,
+		Ports: []config.PortMapping{
+			{Name: "ssh", ListenAddr: "127.0.0.1:0", AgentID: "mac-mini", TargetName: "ssh"},
+		},
+	}
+
+	relayServer, err := relay.NewServer(relayCfg)
+	if err != nil {
+		t.Fatalf("new relay server: %v", err)
+	}
+
+	go func() {
+		if err := relayServer.Start(ctx); err != nil && ctx.Err() == nil {
+			t.Errorf("relay start: %v", err)
+		}
+	}()
+
+	wrongAgentClient, err := agent.NewClient(config.AgentConfig{
+		RelayURL:      relayServer.ControlURL(),
+		AgentID:       "mac-mini",
+		AuthToken:     "office-secret",
+		AllowInsecure: true,
+		Targets: []config.TargetMapping{
+			{Name: "ssh", LocalAddr: startTaggedEchoServer(t, "bad:")},
+		},
+	})
+	if err != nil {
+		t.Fatalf("new wrong-agent client: %v", err)
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- wrongAgentClient.Start(ctx)
+	}()
+
+	select {
+	case err := <-errCh:
+		if err == nil || !strings.Contains(err.Error(), "unauthorized") {
+			t.Fatalf("expected unauthorized error, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("wrong-agent credential was not rejected in time")
+	}
 }
 
 func startEchoServer(t *testing.T) string {

--- a/internal/protocol/message.go
+++ b/internal/protocol/message.go
@@ -1,7 +1,8 @@
 package protocol
 
 type AuthRequest struct {
-	Token string `json:"token"`
+	AgentID string `json:"agent_id"`
+	Token   string `json:"token"`
 }
 
 type RegisterRequest struct {

--- a/internal/relay/server.go
+++ b/internal/relay/server.go
@@ -199,7 +199,7 @@ func (s *Server) authenticate(conn *websocket.Conn) (*session, error) {
 	if err := json.Unmarshal(authFrame.Payload, &auth); err != nil {
 		return nil, err
 	}
-	if !s.isAllowedToken(auth.Token) {
+	if !s.isAllowedAgentToken(auth.AgentID, auth.Token) {
 		_ = writeFrame(conn, protocol.Frame{Type: protocol.FrameError, Payload: []byte("unauthorized")})
 		return nil, errors.New("unauthorized")
 	}
@@ -219,6 +219,10 @@ func (s *Server) authenticate(conn *websocket.Conn) (*session, error) {
 	var register protocol.RegisterRequest
 	if err := json.Unmarshal(registerFrame.Payload, &register); err != nil {
 		return nil, err
+	}
+	if register.AgentID != auth.AgentID {
+		_ = writeFrame(conn, protocol.Frame{Type: protocol.FrameError, Payload: []byte("unauthorized")})
+		return nil, errors.New("unauthorized")
 	}
 
 	targets := make(map[string]struct{}, len(register.Targets))
@@ -350,9 +354,9 @@ func (s *Server) handlePublicConn(ctx context.Context, route config.PortMapping,
 	}
 }
 
-func (s *Server) isAllowedToken(token string) bool {
-	for _, candidate := range s.cfg.AuthTokens {
-		if token == candidate {
+func (s *Server) isAllowedAgentToken(agentID, token string) bool {
+	for _, candidate := range s.cfg.Agents {
+		if candidate.AgentID == agentID && candidate.AuthToken == token {
 			return true
 		}
 	}


### PR DESCRIPTION
## Summary

- Replace the relay's global shared-token list with per-agent credentials in static config
- Bind auth to agent_id ownership before registration while preserving explicit routing and duplicate active-agent rejection
- Extend validation, e2e coverage, and docs for wrong-credential, wrong-agent, and unknown-agent rejection

## Linked Issue

Closes #6

## Closeout Checklist

- [x] Re-read the linked issue after implementation
- [x] Reconciled the canonical plan comment checklist against the shipped code
- [x] No unchecked implementation checklist items remain in the issue body or canonical plan comment
- [x] This PR inherits the linked issue milestone when one exists

## Checklist Audit

- Issue body unchecked items: 0
- Canonical plan comment blocking unchecked items: 0
- Canonical plan comment non-blocking unchecked items: 0
- Canonical plan comment: https://github.com/grepug/gotunnel/issues/6#issuecomment-4288923398

## Validation

- go test ./...
- go test -race ./...
- go build ./cmd/gotunnel ./cmd/gotunneld
