### PR TITLE
feature: persist relay-side agent registrations and last-known state

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,20 +84,21 @@ go build ./cmd/gotunnel ./cmd/gotunneld
 ## Quick start
 
 1. Copy the example configs and replace the per-agent credentials and agent IDs.
-2. For a real deployment, point the relay config at your TLS certificate and key and use a `wss://` relay URL in the agent config.
-3. Start the relay on the VPS:
+2. Choose a relay-local `state_file` path so the relay can persist last-known agent registration state.
+3. For a real deployment, point the relay config at your TLS certificate and key and use a `wss://` relay URL in the agent config.
+4. Start the relay on the VPS:
 
 ```bash
 ./gotunneld -config /path/to/relay.json
 ```
 
-4. Start the agent on the local machine:
+5. Start the agent on the local machine:
 
 ```bash
 ./gotunnel -config /path/to/agent.json
 ```
 
-5. Connect to the VPS public port you mapped.
+6. Connect to the VPS public port you mapped.
 
 Example:
 
@@ -184,6 +185,7 @@ Fields:
 - `agents[].auth_token`: credential accepted only for that named agent
 - `tls_cert_file`: certificate for the control connection
 - `tls_key_file`: private key for the control connection
+- `state_file`: relay-local JSON file for persisted named-agent registration metadata
 - `allow_insecure`: only for local testing; allows plain `ws://`
 - `ports`: public TCP listeners exposed on the VPS
 - `ports[].name`: public listener name
@@ -213,13 +215,14 @@ With both binaries running, connecting to `vps:2222` reaches the local machine's
 
 Different agents can expose the same target name, such as `ssh`, as long as each relay port mapping points to the intended `agent_id` explicitly.
 
+When `state_file` is configured, the relay persists one record per named agent with last-known targets and connection status. That metadata survives relay restarts, but credentials and per-port routing still come from static config.
+
 ## Current limitations
 
 - no hostname-based HTTP routing yet
 - no session preservation across reconnect
 - no multi-agent failover
-- no persistent control-plane state yet
 - no management API for dynamically registering or editing agents
-- no persisted control-plane registrations yet
+- no dynamic agent provisioning yet
 
 Those are deliberate `A`-phase omissions so the transport core can stay small and reliable first.

--- a/examples/relay.json
+++ b/examples/relay.json
@@ -10,6 +10,7 @@
       "auth_token": "replace-me-office-pc"
     }
   ],
+  "state_file": "/var/lib/gotunnel/relay-state.json",
   "tls_cert_file": "/etc/letsencrypt/live/example.com/fullchain.pem",
   "tls_key_file": "/etc/letsencrypt/live/example.com/privkey.pem",
   "ports": [

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,7 @@ import (
 type RelayConfig struct {
 	ControlAddr   string        `json:"control_addr"`
 	Agents        []AgentAuth   `json:"agents"`
+	StateFile     string        `json:"state_file,omitempty"`
 	TLSCertFile   string        `json:"tls_cert_file"`
 	TLSKeyFile    string        `json:"tls_key_file"`
 	AllowInsecure bool          `json:"allow_insecure"`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -101,6 +101,7 @@ func TestLoadRelayConfigFromJSONFile(t *testing.T) {
 		"agents": [
 			{"agent_id": "mac-mini", "auth_token": "secret"}
 		],
+		"state_file": "/tmp/relay-state.json",
 		"allow_insecure": true,
 		"ports": [
 			{"name": "ssh", "listen_addr": "127.0.0.1:0", "agent_id": "mac-mini", "target_name": "ssh"}
@@ -118,6 +119,9 @@ func TestLoadRelayConfigFromJSONFile(t *testing.T) {
 
 	if cfg.ControlAddr != "127.0.0.1:0" {
 		t.Fatalf("unexpected control addr: %s", cfg.ControlAddr)
+	}
+	if cfg.StateFile != "/tmp/relay-state.json" {
+		t.Fatalf("unexpected state file: %s", cfg.StateFile)
 	}
 	if len(cfg.Ports) != 1 || cfg.Ports[0].Name != "ssh" {
 		t.Fatalf("unexpected ports: %+v", cfg.Ports)

--- a/internal/e2e/tunnel_test.go
+++ b/internal/e2e/tunnel_test.go
@@ -2,9 +2,12 @@ package e2e_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"net"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -621,6 +624,108 @@ func TestTunnelRejectsCredentialForDifferentNamedAgent(t *testing.T) {
 	}
 }
 
+func TestRelayPersistsRegistrationStateAcrossDisconnectAndRestart(t *testing.T) {
+	t.Parallel()
+
+	parentCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	controlAddr := reserveTCPAddress(t)
+	publicAddr := reserveTCPAddress(t)
+	stateFile := filepath.Join(t.TempDir(), "relay-state.json")
+	targetAddr := startEchoServer(t)
+
+	relayCfg := config.RelayConfig{
+		ControlAddr: controlAddr,
+		Agents: []config.AgentAuth{
+			{AgentID: "mac-mini", AuthToken: "secret"},
+		},
+		StateFile:     stateFile,
+		AllowInsecure: true,
+		Ports: []config.PortMapping{
+			{Name: "ssh", ListenAddr: publicAddr, AgentID: "mac-mini", TargetName: "ssh"},
+		},
+	}
+
+	relayServer, err := relay.NewServer(relayCfg)
+	if err != nil {
+		t.Fatalf("new relay server: %v", err)
+	}
+
+	relayCtx, stopRelay := context.WithCancel(parentCtx)
+	go func() {
+		if err := relayServer.Start(relayCtx); err != nil && relayCtx.Err() == nil {
+			t.Errorf("relay start: %v", err)
+		}
+	}()
+
+	agentClient, err := agent.NewClient(config.AgentConfig{
+		RelayURL:      relayServer.ControlURL(),
+		AgentID:       "mac-mini",
+		AuthToken:     "secret",
+		AllowInsecure: true,
+		Targets: []config.TargetMapping{
+			{Name: "ssh", LocalAddr: targetAddr},
+		},
+	})
+	if err != nil {
+		t.Fatalf("new agent client: %v", err)
+	}
+
+	go func() {
+		if err := agentClient.Start(parentCtx); err != nil && parentCtx.Err() == nil {
+			t.Errorf("agent start: %v", err)
+		}
+	}()
+
+	waitForForwarding(t, publicAddr)
+	state := waitForRelayState(t, stateFile, "mac-mini", "active")
+	if got := state.Agents["mac-mini"].LastKnownTargets; len(got) != 1 || got[0] != "ssh" {
+		t.Fatalf("unexpected persisted targets: %+v", got)
+	}
+
+	stopRelay()
+	state = waitForRelayState(t, stateFile, "mac-mini", "inactive")
+
+	relayServer, err = relay.NewServer(relayCfg)
+	if err != nil {
+		t.Fatalf("restart relay server: %v", err)
+	}
+
+	relayCtx, stopRelay = context.WithCancel(parentCtx)
+	defer stopRelay()
+	go func() {
+		if err := relayServer.Start(relayCtx); err != nil && relayCtx.Err() == nil {
+			t.Errorf("relay restart: %v", err)
+		}
+	}()
+
+	state = waitForRelayState(t, stateFile, "mac-mini", "inactive")
+	if got := state.Agents["mac-mini"].LastKnownTargets; len(got) != 1 || got[0] != "ssh" {
+		t.Fatalf("unexpected persisted targets after restart: %+v", got)
+	}
+
+	waitForForwarding(t, publicAddr)
+	state = waitForRelayState(t, stateFile, "mac-mini", "active")
+	if len(state.Agents) != 1 {
+		t.Fatalf("expected one persisted agent record, got %d", len(state.Agents))
+	}
+
+	stopRelay()
+	time.Sleep(200 * time.Millisecond)
+}
+
+type relayStateFile struct {
+	Version int                           `json:"version"`
+	Agents  map[string]persistedAgentInfo `json:"agents"`
+}
+
+type persistedAgentInfo struct {
+	AgentID          string   `json:"agent_id"`
+	Status           string   `json:"status"`
+	LastKnownTargets []string `json:"last_known_targets"`
+}
+
 func startEchoServer(t *testing.T) string {
 	t.Helper()
 
@@ -761,4 +866,39 @@ func waitForPublicAddr(t *testing.T, relayServer *relay.Server, name string) str
 
 func isConnClosed(err error) bool {
 	return errors.Is(err, io.EOF) || errors.Is(err, net.ErrClosed)
+}
+
+func waitForRelayState(t *testing.T, path, agentID, wantStatus string) relayStateFile {
+	t.Helper()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		state, err := readRelayState(path)
+		if err == nil {
+			record, ok := state.Agents[agentID]
+			if ok && record.Status == wantStatus {
+				return state
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	t.Fatalf("relay state for %s did not reach status %s in time", agentID, wantStatus)
+	return relayStateFile{}
+}
+
+func readRelayState(path string) (relayStateFile, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return relayStateFile{}, err
+	}
+
+	var state relayStateFile
+	if err := json.Unmarshal(raw, &state); err != nil {
+		return relayStateFile{}, err
+	}
+	if state.Agents == nil {
+		state.Agents = make(map[string]persistedAgentInfo)
+	}
+	return state, nil
 }

--- a/internal/relay/server.go
+++ b/internal/relay/server.go
@@ -32,6 +32,7 @@ type Server struct {
 	controlListener net.Listener
 	publicListeners map[string]net.Listener
 	publicRoutes    map[string]config.PortMapping
+	stateStore      *registrationStore
 
 	httpServer *http.Server
 
@@ -84,6 +85,16 @@ func NewServer(cfg config.RelayConfig) (*Server, error) {
 		publicRoutes:    publicRoutes,
 		sessions:        make(map[string]*session),
 	}
+
+	stateStore, err := newRegistrationStore(cfg.StateFile, cfg.Agents)
+	if err != nil {
+		_ = controlListener.Close()
+		for _, open := range publicListeners {
+			_ = open.Close()
+		}
+		return nil, err
+	}
+	s.stateStore = stateStore
 
 	mux := http.NewServeMux()
 	mux.HandleFunc(controlPath, s.handleControl)
@@ -166,8 +177,14 @@ func (s *Server) handleControl(w http.ResponseWriter, r *http.Request) {
 		_ = conn.Close()
 		return
 	}
+	if err := s.stateStore.markActive(sess.agentID, sess.targets); err != nil {
+		s.clearSession(sess)
+		sess.close()
+		return
+	}
 	if err := sess.write(protocol.Frame{Type: protocol.FrameRegisterOK}); err != nil {
 		s.clearSession(sess)
+		_ = s.stateStore.markInactive(sess.agentID)
 		sess.close()
 		return
 	}
@@ -177,6 +194,7 @@ func (s *Server) handleControl(w http.ResponseWriter, r *http.Request) {
 	defer func() {
 		close(stopHeartbeat)
 		s.clearSession(sess)
+		_ = s.stateStore.markInactive(sess.agentID)
 		sess.close()
 		log.Printf("gotunneld: agent %s session closed", sess.agentID)
 	}()
@@ -411,6 +429,7 @@ func (s *Server) closeSession() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for agentID, sess := range s.sessions {
+		_ = s.stateStore.markInactive(agentID)
 		sess.close()
 		delete(s.sessions, agentID)
 	}

--- a/internal/relay/state.go
+++ b/internal/relay/state.go
@@ -1,0 +1,180 @@
+package relay
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+	"time"
+
+	"gotunnel/internal/config"
+)
+
+const (
+	registrationStateVersion   = 1
+	registrationStatusNever    = "never_connected"
+	registrationStatusActive   = "active"
+	registrationStatusInactive = "inactive"
+)
+
+type registrationStore struct {
+	path string
+
+	mu    sync.Mutex
+	state persistedRelayState
+}
+
+type persistedRelayState struct {
+	Version int                             `json:"version"`
+	Agents  map[string]persistedAgentRecord `json:"agents"`
+}
+
+type persistedAgentRecord struct {
+	AgentID            string    `json:"agent_id"`
+	Status             string    `json:"status"`
+	LastKnownTargets   []string  `json:"last_known_targets"`
+	LastConnectedAt    time.Time `json:"last_connected_at,omitempty"`
+	LastDisconnectedAt time.Time `json:"last_disconnected_at,omitempty"`
+	UpdatedAt          time.Time `json:"updated_at"`
+}
+
+func newRegistrationStore(path string, agents []config.AgentAuth) (*registrationStore, error) {
+	store := &registrationStore{
+		path: path,
+		state: persistedRelayState{
+			Version: registrationStateVersion,
+			Agents:  make(map[string]persistedAgentRecord),
+		},
+	}
+
+	if path != "" {
+		raw, err := os.ReadFile(path)
+		if err == nil {
+			if err := json.Unmarshal(raw, &store.state); err != nil {
+				return nil, err
+			}
+			if store.state.Agents == nil {
+				store.state.Agents = make(map[string]persistedAgentRecord)
+			}
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return nil, err
+		}
+	}
+
+	now := time.Now().UTC()
+	changed := false
+	for _, agent := range agents {
+		record, ok := store.state.Agents[agent.AgentID]
+		if !ok {
+			store.state.Agents[agent.AgentID] = persistedAgentRecord{
+				AgentID:   agent.AgentID,
+				Status:    registrationStatusNever,
+				UpdatedAt: now,
+			}
+			changed = true
+			continue
+		}
+		if record.Status == registrationStatusActive {
+			record.Status = registrationStatusInactive
+			record.LastDisconnectedAt = now
+			record.UpdatedAt = now
+			store.state.Agents[agent.AgentID] = record
+			changed = true
+		}
+	}
+
+	if changed {
+		if err := store.saveLocked(); err != nil {
+			return nil, err
+		}
+	}
+
+	return store, nil
+}
+
+func (s *registrationStore) markActive(agentID string, targets map[string]struct{}) error {
+	if s == nil {
+		return nil
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := time.Now().UTC()
+	record := s.state.Agents[agentID]
+	record.AgentID = agentID
+	record.Status = registrationStatusActive
+	record.LastKnownTargets = sortedTargets(targets)
+	record.LastConnectedAt = now
+	record.UpdatedAt = now
+	s.state.Agents[agentID] = record
+	return s.saveLocked()
+}
+
+func (s *registrationStore) markInactive(agentID string) error {
+	if s == nil {
+		return nil
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	record, ok := s.state.Agents[agentID]
+	if !ok {
+		return nil
+	}
+
+	now := time.Now().UTC()
+	record.Status = registrationStatusInactive
+	record.LastDisconnectedAt = now
+	record.UpdatedAt = now
+	s.state.Agents[agentID] = record
+	return s.saveLocked()
+}
+
+func (s *registrationStore) saveLocked() error {
+	if s.path == "" {
+		return nil
+	}
+
+	s.state.Version = registrationStateVersion
+	raw, err := json.MarshalIndent(s.state, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(s.path), 0o755); err != nil {
+		return err
+	}
+
+	tmpFile, err := os.CreateTemp(filepath.Dir(s.path), "gotunnel-state-*.json")
+	if err != nil {
+		return err
+	}
+	tmpName := tmpFile.Name()
+	if _, err := tmpFile.Write(raw); err != nil {
+		_ = tmpFile.Close()
+		_ = os.Remove(tmpName)
+		return err
+	}
+	if err := tmpFile.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return err
+	}
+	if err := os.Rename(tmpName, s.path); err != nil {
+		_ = os.Remove(tmpName)
+		return err
+	}
+	return nil
+}
+
+func sortedTargets(targets map[string]struct{}) []string {
+	names := make([]string, 0, len(targets))
+	for name := range targets {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}


### PR DESCRIPTION
## Summary

- Add a relay-local state file for persisted named-agent registration metadata
- Persist active and inactive agent lifecycle transitions and reload prior state on relay startup
- Extend end-to-end coverage and docs for register persistence, restart reload, and reconnect refreshing the same record

## Linked Issue

Closes #8

## Closeout Checklist

- [x] Re-read the linked issue after implementation
- [x] Reconciled the canonical plan comment checklist against the shipped code
- [x] No unchecked implementation checklist items remain in the issue body or canonical plan comment
- [x] This PR inherits the linked issue milestone when one exists

## Checklist Audit

- Issue body unchecked items: 0
- Canonical plan comment blocking unchecked items: 0
- Canonical plan comment non-blocking unchecked items: 0
- Canonical plan comment: https://github.com/grepug/gotunnel/issues/8#issuecomment-4289009344

## Validation

- go test ./...
- go test -race ./...
- go build ./cmd/gotunnel ./cmd/gotunneld
