### PR TITLE
feature: add relay status inspection command for persisted agent registrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,24 @@ ssh -p 2222 your-user@your-vps
 
 For local development only, you can set `allow_insecure: true` in both configs and use `ws://.../connect` instead of `wss://.../connect`.
 
+## Inspect relay registration status
+
+If `state_file` is configured, `gotunneld` can print the persisted named-agent registration state without starting the relay server:
+
+```bash
+./gotunneld -config /path/to/relay.json -status
+```
+
+Example output shape:
+
+```text
+home-mac	active	targets=ssh,web	last_connected=2026-04-21T13:00:00Z	last_disconnected=-
+office-pc	inactive	targets=rdp	last_connected=2026-04-21T12:00:00Z	last_disconnected=2026-04-21T13:00:00Z
+lab-mini	never_connected	targets=-	last_connected=-	last_disconnected=-
+```
+
+This command is read-only. It prints the persisted last-known registration state from the relay-owned state file and does not create, edit, or delete relay registrations, credentials, or port mappings.
+
 ## macOS launchd management
 
 For a persistent local agent on macOS, prefer a per-user `LaunchAgent` over an ad hoc background shell process.

--- a/cmd/gotunneld/main.go
+++ b/cmd/gotunneld/main.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
+	"time"
 
 	"gotunnel/internal/config"
 	"gotunnel/internal/relay"
@@ -14,6 +17,7 @@ import (
 
 func main() {
 	configPath := flag.String("config", "", "Path to relay JSON config")
+	statusMode := flag.Bool("status", false, "Print persisted relay registration status and exit")
 	flag.Parse()
 
 	if *configPath == "" {
@@ -21,10 +25,18 @@ func main() {
 		os.Exit(2)
 	}
 
-	cfg, err := config.LoadRelayConfig(*configPath)
+	cfg, err := loadRelayConfig(*configPath, *statusMode)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "load relay config: %v\n", err)
 		os.Exit(1)
+	}
+
+	if *statusMode {
+		if err := renderStatusReport(os.Stdout, cfg); err != nil {
+			fmt.Fprintf(os.Stderr, "render relay status: %v\n", err)
+			os.Exit(1)
+		}
+		return
 	}
 
 	server, err := relay.NewServer(cfg)
@@ -40,4 +52,45 @@ func main() {
 		fmt.Fprintf(os.Stderr, "run relay server: %v\n", err)
 		os.Exit(1)
 	}
+}
+
+func loadRelayConfig(path string, statusMode bool) (config.RelayConfig, error) {
+	if statusMode {
+		return config.LoadRelayStatusConfig(path)
+	}
+	return config.LoadRelayConfig(path)
+}
+
+func renderStatusReport(w io.Writer, cfg config.RelayConfig) error {
+	statuses, err := relay.LoadAgentStatuses(cfg.StateFile, cfg.Agents)
+	if err != nil {
+		return err
+	}
+
+	for _, status := range statuses {
+		targets := "-"
+		if len(status.LastKnownTargets) > 0 {
+			targets = strings.Join(status.LastKnownTargets, ",")
+		}
+		lastConnected := "-"
+		if !status.LastConnectedAt.IsZero() {
+			lastConnected = status.LastConnectedAt.Format(time.RFC3339)
+		}
+		lastDisconnected := "-"
+		if !status.LastDisconnectedAt.IsZero() {
+			lastDisconnected = status.LastDisconnectedAt.Format(time.RFC3339)
+		}
+		if _, err := fmt.Fprintf(
+			w,
+			"%s\t%s\ttargets=%s\tlast_connected=%s\tlast_disconnected=%s\n",
+			status.AgentID,
+			status.Status,
+			targets,
+			lastConnected,
+			lastDisconnected,
+		); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/cmd/gotunneld/main_test.go
+++ b/cmd/gotunneld/main_test.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"gotunnel/internal/config"
+)
+
+func TestRenderStatusReportShowsNeverConnectedAgentWhenStateFileIsMissing(t *testing.T) {
+	cfg := config.RelayConfig{
+		Agents: []config.AgentAuth{
+			{AgentID: "mac-mini", AuthToken: "secret"},
+		},
+		StateFile: filepath.Join(t.TempDir(), "missing-state.json"),
+	}
+
+	var out bytes.Buffer
+	if err := renderStatusReport(&out, cfg); err != nil {
+		t.Fatalf("render status report: %v", err)
+	}
+
+	text := out.String()
+	if !strings.Contains(text, "mac-mini") || !strings.Contains(text, "never_connected") {
+		t.Fatalf("unexpected status output: %s", text)
+	}
+}
+
+func TestRenderStatusReportShowsActiveAndInactiveAgents(t *testing.T) {
+	statePath := filepath.Join(t.TempDir(), "relay-state.json")
+	now := time.Date(2026, 4, 21, 13, 0, 0, 0, time.UTC)
+	state := map[string]any{
+		"version": 1,
+		"agents": map[string]any{
+			"mac-mini": map[string]any{
+				"agent_id":           "mac-mini",
+				"status":             "active",
+				"last_known_targets": []string{"ssh", "web"},
+				"last_connected_at":  now.Format(time.RFC3339),
+				"updated_at":         now.Format(time.RFC3339),
+			},
+			"office-pc": map[string]any{
+				"agent_id":             "office-pc",
+				"status":               "inactive",
+				"last_known_targets":   []string{"rdp"},
+				"last_connected_at":    now.Add(-time.Hour).Format(time.RFC3339),
+				"last_disconnected_at": now.Format(time.RFC3339),
+				"updated_at":           now.Format(time.RFC3339),
+			},
+		},
+	}
+	raw, err := json.Marshal(state)
+	if err != nil {
+		t.Fatalf("marshal state: %v", err)
+	}
+	if err := os.WriteFile(statePath, raw, 0o600); err != nil {
+		t.Fatalf("write state file: %v", err)
+	}
+
+	cfg := config.RelayConfig{
+		Agents: []config.AgentAuth{
+			{AgentID: "mac-mini", AuthToken: "secret"},
+			{AgentID: "office-pc", AuthToken: "office-secret"},
+		},
+		StateFile: statePath,
+	}
+
+	var out bytes.Buffer
+	if err := renderStatusReport(&out, cfg); err != nil {
+		t.Fatalf("render status report: %v", err)
+	}
+
+	text := out.String()
+	for _, want := range []string{"mac-mini", "active", "ssh,web", "office-pc", "inactive", "rdp"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("expected %q in status output: %s", want, text)
+		}
+	}
+}
+
+func TestLoadRelayConfigUsesRelaxedValidationForStatusMode(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "relay.json")
+	content := `{
+		"agents": [
+			{"agent_id": "mac-mini", "auth_token": "secret"}
+		],
+		"state_file": "/tmp/relay-state.json"
+	}`
+	if err := os.WriteFile(configPath, []byte(content), 0o600); err != nil {
+		t.Fatalf("write relay config: %v", err)
+	}
+
+	cfg, err := loadRelayConfig(configPath, true)
+	if err != nil {
+		t.Fatalf("load relay config for status mode: %v", err)
+	}
+	if cfg.StateFile != "/tmp/relay-state.json" {
+		t.Fatalf("unexpected state file: %s", cfg.StateFile)
+	}
+	if len(cfg.Agents) != 1 || cfg.Agents[0].AgentID != "mac-mini" {
+		t.Fatalf("unexpected agents: %+v", cfg.Agents)
+	}
+}
+
+func TestLoadRelayConfigRequiresFullValidationOutsideStatusMode(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "relay.json")
+	content := `{
+		"agents": [
+			{"agent_id": "mac-mini", "auth_token": "secret"}
+		],
+		"state_file": "/tmp/relay-state.json"
+	}`
+	if err := os.WriteFile(configPath, []byte(content), 0o600); err != nil {
+		t.Fatalf("write relay config: %v", err)
+	}
+
+	if _, err := loadRelayConfig(configPath, false); err == nil {
+		t.Fatal("expected full relay validation to fail without runtime fields")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -49,9 +49,6 @@ func (c RelayConfig) Validate() error {
 	if _, err := net.ResolveTCPAddr("tcp", c.ControlAddr); err != nil {
 		return fmt.Errorf("invalid control address: %w", err)
 	}
-	if len(c.Agents) == 0 {
-		return errors.New("at least one agent credential is required")
-	}
 	if (c.TLSCertFile == "") != (c.TLSKeyFile == "") {
 		return errors.New("tls_cert_file and tls_key_file must be set together")
 	}
@@ -62,18 +59,13 @@ func (c RelayConfig) Validate() error {
 		return errors.New("at least one port mapping is required")
 	}
 
+	if err := c.validateAgentAuths(); err != nil {
+		return err
+	}
+
 	knownAgents := make(map[string]struct{}, len(c.Agents))
 	for _, agent := range c.Agents {
-		if agent.AgentID == "" {
-			return errors.New("agent_id is required for relay agent credentials")
-		}
-		if _, exists := knownAgents[agent.AgentID]; exists {
-			return fmt.Errorf("duplicate relay agent id: %s", agent.AgentID)
-		}
 		knownAgents[agent.AgentID] = struct{}{}
-		if agent.AuthToken == "" {
-			return fmt.Errorf("auth_token is required for relay agent %s", agent.AgentID)
-		}
 	}
 
 	seen := make(map[string]struct{}, len(c.Ports))
@@ -100,6 +92,32 @@ func (c RelayConfig) Validate() error {
 		}
 		if port.TargetName == "" {
 			return fmt.Errorf("target_name is required for port mapping %s", port.Name)
+		}
+	}
+
+	return nil
+}
+
+func (c RelayConfig) ValidateStatusMode() error {
+	return c.validateAgentAuths()
+}
+
+func (c RelayConfig) validateAgentAuths() error {
+	if len(c.Agents) == 0 {
+		return errors.New("at least one agent credential is required")
+	}
+
+	knownAgents := make(map[string]struct{}, len(c.Agents))
+	for _, agent := range c.Agents {
+		if agent.AgentID == "" {
+			return errors.New("agent_id is required for relay agent credentials")
+		}
+		if _, exists := knownAgents[agent.AgentID]; exists {
+			return fmt.Errorf("duplicate relay agent id: %s", agent.AgentID)
+		}
+		knownAgents[agent.AgentID] = struct{}{}
+		if agent.AuthToken == "" {
+			return fmt.Errorf("auth_token is required for relay agent %s", agent.AgentID)
 		}
 	}
 

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -17,6 +17,17 @@ func LoadRelayConfig(path string) (RelayConfig, error) {
 	return cfg, nil
 }
 
+func LoadRelayStatusConfig(path string) (RelayConfig, error) {
+	var cfg RelayConfig
+	if err := loadJSON(path, &cfg); err != nil {
+		return RelayConfig{}, err
+	}
+	if err := cfg.ValidateStatusMode(); err != nil {
+		return RelayConfig{}, err
+	}
+	return cfg, nil
+}
+
 func LoadAgentConfig(path string) (AgentConfig, error) {
 	var cfg AgentConfig
 	if err := loadJSON(path, &cfg); err != nil {

--- a/internal/relay/state.go
+++ b/internal/relay/state.go
@@ -40,6 +40,56 @@ type persistedAgentRecord struct {
 	UpdatedAt          time.Time `json:"updated_at"`
 }
 
+type AgentStatus struct {
+	AgentID            string
+	Status             string
+	LastKnownTargets   []string
+	LastConnectedAt    time.Time
+	LastDisconnectedAt time.Time
+	UpdatedAt          time.Time
+}
+
+func LoadAgentStatuses(path string, agents []config.AgentAuth) ([]AgentStatus, error) {
+	state, err := loadPersistedRelayState(path)
+	if err != nil {
+		return nil, err
+	}
+
+	now := time.Now().UTC()
+	if state.Agents == nil {
+		state.Agents = make(map[string]persistedAgentRecord)
+	}
+	for _, agent := range agents {
+		if _, ok := state.Agents[agent.AgentID]; !ok {
+			state.Agents[agent.AgentID] = persistedAgentRecord{
+				AgentID:   agent.AgentID,
+				Status:    registrationStatusNever,
+				UpdatedAt: now,
+			}
+		}
+	}
+
+	ids := make([]string, 0, len(state.Agents))
+	for agentID := range state.Agents {
+		ids = append(ids, agentID)
+	}
+	sort.Strings(ids)
+
+	statuses := make([]AgentStatus, 0, len(ids))
+	for _, agentID := range ids {
+		record := state.Agents[agentID]
+		statuses = append(statuses, AgentStatus{
+			AgentID:            record.AgentID,
+			Status:             record.Status,
+			LastKnownTargets:   append([]string(nil), record.LastKnownTargets...),
+			LastConnectedAt:    record.LastConnectedAt,
+			LastDisconnectedAt: record.LastDisconnectedAt,
+			UpdatedAt:          record.UpdatedAt,
+		})
+	}
+	return statuses, nil
+}
+
 func newRegistrationStore(path string, agents []config.AgentAuth) (*registrationStore, error) {
 	store := &registrationStore{
 		path: path,
@@ -50,17 +100,11 @@ func newRegistrationStore(path string, agents []config.AgentAuth) (*registration
 	}
 
 	if path != "" {
-		raw, err := os.ReadFile(path)
-		if err == nil {
-			if err := json.Unmarshal(raw, &store.state); err != nil {
-				return nil, err
-			}
-			if store.state.Agents == nil {
-				store.state.Agents = make(map[string]persistedAgentRecord)
-			}
-		} else if !errors.Is(err, os.ErrNotExist) {
+		state, err := loadPersistedRelayState(path)
+		if err != nil {
 			return nil, err
 		}
+		store.state = state
 	}
 
 	now := time.Now().UTC()
@@ -92,6 +136,31 @@ func newRegistrationStore(path string, agents []config.AgentAuth) (*registration
 	}
 
 	return store, nil
+}
+
+func loadPersistedRelayState(path string) (persistedRelayState, error) {
+	state := persistedRelayState{
+		Version: registrationStateVersion,
+		Agents:  make(map[string]persistedAgentRecord),
+	}
+	if path == "" {
+		return state, nil
+	}
+
+	raw, err := os.ReadFile(path)
+	if err == nil {
+		if err := json.Unmarshal(raw, &state); err != nil {
+			return persistedRelayState{}, err
+		}
+		if state.Agents == nil {
+			state.Agents = make(map[string]persistedAgentRecord)
+		}
+		return state, nil
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		return state, nil
+	}
+	return persistedRelayState{}, err
 }
 
 func (s *registrationStore) markActive(agentID string, targets map[string]struct{}) error {


### PR DESCRIPTION
## Summary

- Add gotunneld -status mode for persisted relay registration inspection
- Load status mode without full runtime relay validation and document read-only usage

## Linked Issue

Closes #10

## Closeout Checklist

- [x] Re-read the linked issue after implementation
- [x] Reconciled the canonical plan comment checklist against the shipped code
- [x] No unchecked implementation checklist items remain in the issue body or canonical plan comment
- [x] This PR inherits the linked issue milestone when one exists

## Checklist Audit

- Issue body unchecked items: 0
- Canonical plan comment blocking unchecked items: 0
- Canonical plan comment non-blocking unchecked items: 0
- Canonical plan comment: https://github.com/grepug/gotunnel/issues/10#issuecomment-4289107935

## Validation

- go test ./...
- go test -race ./...
- go build ./cmd/gotunnel ./cmd/gotunneld
