### PR TITLE
bug: normalize stale active relay registrations in offline status mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,12 +125,14 @@ If `state_file` is configured, `gotunneld` can print the persisted named-agent r
 Example output shape:
 
 ```text
-home-mac	active	targets=ssh,web	last_connected=2026-04-21T13:00:00Z	last_disconnected=-
+home-mac	inactive	targets=ssh,web	last_connected=2026-04-21T13:00:00Z	last_disconnected=-
 office-pc	inactive	targets=rdp	last_connected=2026-04-21T12:00:00Z	last_disconnected=2026-04-21T13:00:00Z
 lab-mini	never_connected	targets=-	last_connected=-	last_disconnected=-
 ```
 
 This command is read-only. It prints the persisted last-known registration state from the relay-owned state file and does not create, edit, or delete relay registrations, credentials, or port mappings.
+
+Because `-status` does not coordinate with a live relay runtime, it renders persisted `active` records conservatively as offline `inactive` while preserving the last-known targets and connect timestamps.
 
 ## macOS launchd management
 

--- a/cmd/gotunneld/main_test.go
+++ b/cmd/gotunneld/main_test.go
@@ -31,7 +31,7 @@ func TestRenderStatusReportShowsNeverConnectedAgentWhenStateFileIsMissing(t *tes
 	}
 }
 
-func TestRenderStatusReportShowsActiveAndInactiveAgents(t *testing.T) {
+func TestRenderStatusReportNormalizesOfflineActiveAgentWithoutMutatingState(t *testing.T) {
 	statePath := filepath.Join(t.TempDir(), "relay-state.json")
 	now := time.Date(2026, 4, 21, 13, 0, 0, 0, time.UTC)
 	state := map[string]any{
@@ -58,6 +58,7 @@ func TestRenderStatusReportShowsActiveAndInactiveAgents(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal state: %v", err)
 	}
+	original := append([]byte(nil), raw...)
 	if err := os.WriteFile(statePath, raw, 0o600); err != nil {
 		t.Fatalf("write state file: %v", err)
 	}
@@ -76,10 +77,21 @@ func TestRenderStatusReportShowsActiveAndInactiveAgents(t *testing.T) {
 	}
 
 	text := out.String()
-	for _, want := range []string{"mac-mini", "active", "ssh,web", "office-pc", "inactive", "rdp"} {
+	for _, want := range []string{"mac-mini", "inactive", "ssh,web", "office-pc", "rdp"} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("expected %q in status output: %s", want, text)
 		}
+	}
+	if strings.Contains(text, "\tactive\t") {
+		t.Fatalf("expected offline status to avoid active records: %s", text)
+	}
+
+	persistedAfter, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatalf("read state file after status render: %v", err)
+	}
+	if !bytes.Equal(persistedAfter, original) {
+		t.Fatalf("status render mutated state file: before=%s after=%s", string(original), string(persistedAfter))
 	}
 }
 

--- a/internal/relay/state.go
+++ b/internal/relay/state.go
@@ -78,9 +78,16 @@ func LoadAgentStatuses(path string, agents []config.AgentAuth) ([]AgentStatus, e
 	statuses := make([]AgentStatus, 0, len(ids))
 	for _, agentID := range ids {
 		record := state.Agents[agentID]
+		status := record.Status
+		if status == registrationStatusActive {
+			status = registrationStatusInactive
+		}
+		if record.AgentID == "" {
+			record.AgentID = agentID
+		}
 		statuses = append(statuses, AgentStatus{
 			AgentID:            record.AgentID,
-			Status:             record.Status,
+			Status:             status,
 			LastKnownTargets:   append([]string(nil), record.LastKnownTargets...),
 			LastConnectedAt:    record.LastConnectedAt,
 			LastDisconnectedAt: record.LastDisconnectedAt,


### PR DESCRIPTION
## Summary

- Normalize stale persisted active records in offline status output
- Keep the status path read-only and document the conservative offline interpretation

## Linked Issue

Closes #12

## Closeout Checklist

- [x] Re-read the linked issue after implementation
- [x] Reconciled the canonical plan comment checklist against the shipped code
- [x] No unchecked implementation checklist items remain in the issue body or canonical plan comment
- [x] This PR inherits the linked issue milestone when one exists

## Checklist Audit

- Issue body unchecked items: 0
- Canonical plan comment blocking unchecked items: 0
- Canonical plan comment non-blocking unchecked items: 0
- Canonical plan comment: https://github.com/grepug/gotunnel/issues/12#issuecomment-4289349385

## Validation

- go test ./...
- go test -race ./...
- go build ./cmd/gotunnel ./cmd/gotunneld
