### PR TITLE
feature: add an agent CLI and default ~/.gotunnel config home

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,35 +58,58 @@ go build ./cmd/gotunnel ./cmd/gotunneld
 
 Start with SSH first. It is the smallest success path and the easiest to verify.
 
-### 1. Create an agent config
+### VPS Side
 
-Example:
+Before the local machine does anything, the relay operator or VPS owner should already have:
 
-- [examples/agent.json](examples/agent.json)
+- a running `gotunneld` relay
+- one public SSH port mapped to your agent, such as `2222`
+- your assigned `relay_url`
+- your assigned `agent_id`
+- your assigned `auth_token`
 
-Minimal agent config:
+### Host Machine Side
 
-```json
-{
-  "relay_url": "wss://your-vps:18443/connect",
-  "agent_id": "home-mac",
-  "auth_token": "replace-me-home-mac",
-  "targets": [
-    {
-      "name": "ssh",
-      "local_addr": "127.0.0.1:22"
-    }
-  ]
-}
-```
-
-### 2. Start the agent
+### 1. Initialize local config
 
 ```bash
-./gotunnel -config /path/to/agent.json
+./gotunnel init
 ```
 
-### 3. Test SSH through the VPS
+This creates the default local config home at `~/.gotunnel/agent.json`.
+
+### 2. Save relay and auth settings
+
+```bash
+./gotunnel set relay --url wss://your-vps:18443/connect
+./gotunnel set auth --agent-id home-mac --auth-token replace-me-home-mac
+```
+
+For local development only, you can use:
+
+```bash
+./gotunnel set relay --url ws://your-vps:18443/connect --allow-insecure
+```
+
+### 3. Add the SSH target
+
+```bash
+./gotunnel target add --name ssh --local-addr 127.0.0.1:22
+```
+
+You can inspect the stored config any time with:
+
+```bash
+./gotunnel show
+```
+
+### 4. Start the agent
+
+```bash
+./gotunnel run
+```
+
+### 5. Test SSH through the VPS
 
 ```bash
 ssh -p 2222 your-user@your-vps
@@ -96,19 +119,20 @@ This example uses public SSH port `2222`. Use the public port that your relay op
 
 If that works, the tunnel is up.
 
-For local development only, you can set `allow_insecure: true` and use `ws://.../connect` instead of `wss://.../connect`.
-
 ## Add More Targets
 
-Once SSH works, adding `web` and `desktop` is only more config.
+Once SSH works, adding `web` and `desktop` is only more commands.
+
+### VPS side
+
+For each extra target, the relay operator or VPS owner still needs to map a public port to that target name on your agent.
 
 ### Add a web target
 
-```json
-{
-  "name": "web",
-  "local_addr": "127.0.0.1:3000"
-}
+### Host machine side
+
+```bash
+./gotunnel target add --name web --local-addr 127.0.0.1:3000
 ```
 
 Test:
@@ -121,11 +145,10 @@ This example uses public web port `28080`. Use the public port assigned on your 
 
 ### Add a desktop target
 
-```json
-{
-  "name": "desktop",
-  "local_addr": "127.0.0.1:5900"
-}
+### Host machine side
+
+```bash
+./gotunnel target add --name desktop --local-addr 127.0.0.1:5900
 ```
 
 `desktop` is only a label. The relay does not care whether the local service behind that label is VNC, RDP, or another TCP desktop protocol.
@@ -157,7 +180,7 @@ If you want the local agent to stay up through login sessions and restarts on ma
 ## Examples
 
 - relay example: [examples/relay.json](examples/relay.json)
-- agent example: [examples/agent.json](examples/agent.json)
+- agent JSON example for advanced/manual use: [examples/agent.json](examples/agent.json)
 - macOS launchd example: [examples/gotunnel.agent.plist.example](examples/gotunnel.agent.plist.example)
 
 The shipped examples use one consistent naming scheme:
@@ -178,6 +201,7 @@ The shipped examples use one consistent naming scheme:
 - encrypted control plane by default
 
 Plain `ws://` is only allowed when `allow_insecure` is explicitly set to `true`.
+Manual JSON configs are still supported through `./gotunnel -config /path/to/agent.json` and `./gotunnel run -config /path/to/agent.json`.
 
 ## Troubleshooting
 

--- a/cmd/gotunnel/main.go
+++ b/cmd/gotunnel/main.go
@@ -4,8 +4,12 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"io"
+	"net"
+	"net/url"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 
 	"gotunnel/internal/agent"
@@ -13,31 +17,313 @@ import (
 )
 
 func main() {
-	configPath := flag.String("config", "", "Path to agent JSON config")
-	flag.Parse()
+	if err := run(os.Args[1:], os.Stdout, os.Stderr); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
 
-	if *configPath == "" {
-		fmt.Fprintln(os.Stderr, "-config is required")
-		os.Exit(2)
+func run(args []string, stdout, stderr io.Writer) error {
+	if len(args) == 0 {
+		return fmt.Errorf("expected a command such as init, set, target, show, or run")
 	}
 
-	cfg, err := config.LoadAgentConfig(*configPath)
+	if strings.HasPrefix(args[0], "-") {
+		return runLegacy(args)
+	}
+
+	switch args[0] {
+	case "init":
+		return runInit(args[1:], stdout)
+	case "set":
+		return runSet(args[1:], stdout)
+	case "target":
+		return runTarget(args[1:], stdout)
+	case "show":
+		return runShow(args[1:], stdout)
+	case "run":
+		return runAgentCommand(args[1:])
+	default:
+		return fmt.Errorf("unknown command %q", args[0])
+	}
+}
+
+func runLegacy(args []string) error {
+	fs := flag.NewFlagSet("gotunnel", flag.ContinueOnError)
+	configPath := fs.String("config", "", "Path to agent JSON config")
+	fs.SetOutput(io.Discard)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *configPath == "" {
+		return fmt.Errorf("-config is required")
+	}
+	return runAgentWithPath(*configPath)
+}
+
+func runInit(args []string, stdout io.Writer) error {
+	fs := flag.NewFlagSet("init", flag.ContinueOnError)
+	configPath := fs.String("config", "", "Path to agent JSON config")
+	fs.SetOutput(io.Discard)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	path, err := resolveAgentConfigPath(*configPath)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "load agent config: %v\n", err)
-		os.Exit(1)
+		return err
+	}
+	if _, err := os.Stat(path); err == nil {
+		fmt.Fprintf(stdout, "agent config already exists at %s\n", path)
+		return nil
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("stat config %s: %w", path, err)
+	}
+
+	cfg := config.AgentConfig{
+		Targets: []config.TargetMapping{},
+	}
+	if err := config.SaveAgentConfig(path, cfg); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(stdout, "initialized agent config at %s\n", path)
+	return nil
+}
+
+func runSet(args []string, stdout io.Writer) error {
+	if len(args) == 0 {
+		return fmt.Errorf("expected a set subcommand")
+	}
+
+	switch args[0] {
+	case "relay":
+		return runSetRelay(args[1:], stdout)
+	case "auth":
+		return runSetAuth(args[1:], stdout)
+	default:
+		return fmt.Errorf("unknown set subcommand %q", args[0])
+	}
+}
+
+func runSetRelay(args []string, stdout io.Writer) error {
+	fs := flag.NewFlagSet("set relay", flag.ContinueOnError)
+	configPath := fs.String("config", "", "Path to agent JSON config")
+	relayURL := fs.String("url", "", "Relay URL")
+	allowInsecure := fs.Bool("allow-insecure", false, "Allow plain ws relay URLs")
+	fs.SetOutput(io.Discard)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *relayURL == "" {
+		return fmt.Errorf("--url is required")
+	}
+
+	path, cfg, err := loadDraftConfig(*configPath)
+	if err != nil {
+		return err
+	}
+	if err := validateRelayURL(*relayURL, *allowInsecure || cfg.AllowInsecure); err != nil {
+		return err
+	}
+	cfg.RelayURL = *relayURL
+	cfg.AllowInsecure = *allowInsecure
+	if cfg.Targets == nil {
+		cfg.Targets = []config.TargetMapping{}
+	}
+
+	if err := config.SaveAgentConfig(path, cfg); err != nil {
+		return err
+	}
+	fmt.Fprintf(stdout, "updated relay settings in %s\n", path)
+	return nil
+}
+
+func runSetAuth(args []string, stdout io.Writer) error {
+	fs := flag.NewFlagSet("set auth", flag.ContinueOnError)
+	configPath := fs.String("config", "", "Path to agent JSON config")
+	agentID := fs.String("agent-id", "", "Agent ID")
+	authToken := fs.String("auth-token", "", "Auth token")
+	fs.SetOutput(io.Discard)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *agentID == "" {
+		return fmt.Errorf("--agent-id is required")
+	}
+	if *authToken == "" {
+		return fmt.Errorf("--auth-token is required")
+	}
+
+	path, cfg, err := loadDraftConfig(*configPath)
+	if err != nil {
+		return err
+	}
+	cfg.AgentID = *agentID
+	cfg.AuthToken = *authToken
+	if cfg.Targets == nil {
+		cfg.Targets = []config.TargetMapping{}
+	}
+
+	if err := config.SaveAgentConfig(path, cfg); err != nil {
+		return err
+	}
+	fmt.Fprintf(stdout, "updated auth settings in %s\n", path)
+	return nil
+}
+
+func runTarget(args []string, stdout io.Writer) error {
+	if len(args) == 0 {
+		return fmt.Errorf("expected a target subcommand")
+	}
+
+	switch args[0] {
+	case "add":
+		return runTargetAdd(args[1:], stdout)
+	default:
+		return fmt.Errorf("unknown target subcommand %q", args[0])
+	}
+}
+
+func runTargetAdd(args []string, stdout io.Writer) error {
+	fs := flag.NewFlagSet("target add", flag.ContinueOnError)
+	configPath := fs.String("config", "", "Path to agent JSON config")
+	name := fs.String("name", "", "Target name")
+	localAddr := fs.String("local-addr", "", "Local address")
+	fs.SetOutput(io.Discard)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *name == "" {
+		return fmt.Errorf("--name is required")
+	}
+	if *localAddr == "" {
+		return fmt.Errorf("--local-addr is required")
+	}
+	if _, err := net.ResolveTCPAddr("tcp", *localAddr); err != nil {
+		return fmt.Errorf("invalid local address: %w", err)
+	}
+
+	path, cfg, err := loadDraftConfig(*configPath)
+	if err != nil {
+		return err
+	}
+	if cfg.Targets == nil {
+		cfg.Targets = []config.TargetMapping{}
+	}
+
+	replaced := false
+	for i := range cfg.Targets {
+		if cfg.Targets[i].Name == *name {
+			cfg.Targets[i].LocalAddr = *localAddr
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		cfg.Targets = append(cfg.Targets, config.TargetMapping{Name: *name, LocalAddr: *localAddr})
+	}
+
+	if err := config.SaveAgentConfig(path, cfg); err != nil {
+		return err
+	}
+	fmt.Fprintf(stdout, "updated targets in %s\n", path)
+	return nil
+}
+
+func runShow(args []string, stdout io.Writer) error {
+	fs := flag.NewFlagSet("show", flag.ContinueOnError)
+	configPath := fs.String("config", "", "Path to agent JSON config")
+	fs.SetOutput(io.Discard)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	path, cfg, err := loadDraftConfig(*configPath)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(stdout, "config: %s\n", path)
+	fmt.Fprintf(stdout, "relay_url: %s\n", cfg.RelayURL)
+	fmt.Fprintf(stdout, "agent_id: %s\n", cfg.AgentID)
+	if len(cfg.Targets) == 0 {
+		fmt.Fprintln(stdout, "targets: -")
+		return nil
+	}
+
+	fmt.Fprintln(stdout, "targets:")
+	for _, target := range cfg.Targets {
+		fmt.Fprintf(stdout, "%s -> %s\n", target.Name, target.LocalAddr)
+	}
+	return nil
+}
+
+func runAgentCommand(args []string) error {
+	fs := flag.NewFlagSet("run", flag.ContinueOnError)
+	configPath := fs.String("config", "", "Path to agent JSON config")
+	fs.SetOutput(io.Discard)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	path, err := resolveAgentConfigPath(*configPath)
+	if err != nil {
+		return err
+	}
+	return runAgentWithPath(path)
+}
+
+func runAgentWithPath(path string) error {
+	cfg, err := config.LoadAgentConfig(path)
+	if err != nil {
+		return fmt.Errorf("load agent config: %w", err)
 	}
 
 	client, err := agent.NewClient(cfg)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "create agent client: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("create agent client: %w", err)
 	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
 	if err := client.Start(ctx); err != nil {
-		fmt.Fprintf(os.Stderr, "run agent client: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("run agent client: %w", err)
 	}
+	return nil
+}
+
+func loadDraftConfig(explicitPath string) (string, config.AgentConfig, error) {
+	path, err := resolveAgentConfigPath(explicitPath)
+	if err != nil {
+		return "", config.AgentConfig{}, err
+	}
+
+	cfg, err := config.LoadAgentDraftConfig(path)
+	if err != nil {
+		return "", config.AgentConfig{}, fmt.Errorf("load agent config: %w", err)
+	}
+	return path, cfg, nil
+}
+
+func resolveAgentConfigPath(explicitPath string) (string, error) {
+	if explicitPath != "" {
+		return explicitPath, nil
+	}
+	return config.DefaultAgentConfigPath()
+}
+
+func validateRelayURL(rawURL string, allowInsecure bool) error {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid relay URL: %w", err)
+	}
+	if parsed.Scheme != "ws" && parsed.Scheme != "wss" {
+		return fmt.Errorf("unsupported relay URL scheme: %s", parsed.Scheme)
+	}
+	if parsed.Scheme == "ws" && !allowInsecure {
+		return fmt.Errorf("plain ws relay URL requires allow_insecure to be true")
+	}
+	return nil
 }

--- a/cmd/gotunnel/main_test.go
+++ b/cmd/gotunnel/main_test.go
@@ -1,0 +1,195 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gotunnel/internal/config"
+)
+
+func TestRunInitCreatesDefaultAgentConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	var stdout bytes.Buffer
+	if err := run([]string{"init"}, &stdout, &stdout); err != nil {
+		t.Fatalf("run init: %v", err)
+	}
+
+	path := filepath.Join(home, ".gotunnel", "agent.json")
+	raw := readFile(t, path)
+
+	var cfg config.AgentConfig
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		t.Fatalf("decode init config: %v", err)
+	}
+
+	if len(cfg.Targets) != 0 {
+		t.Fatalf("unexpected targets after init: %+v", cfg.Targets)
+	}
+	if !strings.Contains(stdout.String(), path) {
+		t.Fatalf("expected output to mention config path, got %q", stdout.String())
+	}
+}
+
+func TestRunSetRelayAuthTargetAndShowUseDefaultConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	var stdout bytes.Buffer
+	for _, args := range [][]string{
+		{"init"},
+		{"set", "relay", "--url", "ws://127.0.0.1:18443/connect", "--allow-insecure"},
+		{"set", "auth", "--agent-id", "home-mac", "--auth-token", "secret"},
+		{"target", "add", "--name", "ssh", "--local-addr", "127.0.0.1:22"},
+	} {
+		stdout.Reset()
+		if err := run(args, &stdout, &stdout); err != nil {
+			t.Fatalf("run %v: %v", args, err)
+		}
+	}
+
+	cfg, err := config.LoadDefaultAgentConfig()
+	if err != nil {
+		t.Fatalf("load default agent config: %v", err)
+	}
+
+	if cfg.RelayURL != "ws://127.0.0.1:18443/connect" {
+		t.Fatalf("unexpected relay url: %q", cfg.RelayURL)
+	}
+	if !cfg.AllowInsecure {
+		t.Fatal("expected allow_insecure to be set")
+	}
+	if cfg.AgentID != "home-mac" {
+		t.Fatalf("unexpected agent id: %q", cfg.AgentID)
+	}
+	if len(cfg.Targets) != 1 || cfg.Targets[0].Name != "ssh" {
+		t.Fatalf("unexpected targets: %+v", cfg.Targets)
+	}
+
+	stdout.Reset()
+	if err := run([]string{"show"}, &stdout, &stdout); err != nil {
+		t.Fatalf("run show: %v", err)
+	}
+
+	text := stdout.String()
+	for _, want := range []string{"home-mac", "ws://127.0.0.1:18443/connect", "ssh -> 127.0.0.1:22"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("expected %q in show output: %s", want, text)
+		}
+	}
+}
+
+func TestRunTargetAddRejectsInvalidLocalAddr(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	var stdout bytes.Buffer
+	if err := run([]string{"init"}, &stdout, &stdout); err != nil {
+		t.Fatalf("run init: %v", err)
+	}
+
+	err := run([]string{"target", "add", "--name", "ssh", "--local-addr", "not-a-tcp-address"}, &stdout, &stdout)
+	if err == nil {
+		t.Fatal("expected invalid local address to fail")
+	}
+	if !strings.Contains(err.Error(), "invalid local address") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunSetRelayRejectsPlainWSWithoutAllowInsecure(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	var stdout bytes.Buffer
+	if err := run([]string{"init"}, &stdout, &stdout); err != nil {
+		t.Fatalf("run init: %v", err)
+	}
+
+	err := run([]string{"set", "relay", "--url", "ws://127.0.0.1:18443/connect"}, &stdout, &stdout)
+	if err == nil {
+		t.Fatal("expected plain ws relay url to fail without --allow-insecure")
+	}
+	if !strings.Contains(err.Error(), "allow_insecure") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunSetRelayRejectsUnsupportedRelayScheme(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	var stdout bytes.Buffer
+	if err := run([]string{"init"}, &stdout, &stdout); err != nil {
+		t.Fatalf("run init: %v", err)
+	}
+
+	err := run([]string{"set", "relay", "--url", "http://127.0.0.1:18443/connect"}, &stdout, &stdout)
+	if err == nil {
+		t.Fatal("expected unsupported relay scheme to fail")
+	}
+	if !strings.Contains(err.Error(), "unsupported relay URL scheme") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunLegacyConfigFlagKeepsCompatibilityPath(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "missing-agent.json")
+
+	var stdout bytes.Buffer
+	err := run([]string{"-config", missing}, &stdout, &stdout)
+	if err == nil {
+		t.Fatal("expected missing explicit config to fail")
+	}
+	if !strings.Contains(err.Error(), "load agent config") || !strings.Contains(err.Error(), missing) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunSubcommandsSupportExplicitConfigPath(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "custom-agent.json")
+
+	var stdout bytes.Buffer
+	for _, args := range [][]string{
+		{"init", "--config", path},
+		{"set", "relay", "--config", path, "--url", "ws://127.0.0.1:18443/connect", "--allow-insecure"},
+		{"set", "auth", "--config", path, "--agent-id", "office-mac", "--auth-token", "secret"},
+		{"target", "add", "--config", path, "--name", "ssh", "--local-addr", "127.0.0.1:22"},
+	} {
+		stdout.Reset()
+		if err := run(args, &stdout, &stdout); err != nil {
+			t.Fatalf("run %v: %v", args, err)
+		}
+	}
+
+	cfg, err := config.LoadAgentConfig(path)
+	if err != nil {
+		t.Fatalf("load explicit config: %v", err)
+	}
+	if cfg.AgentID != "office-mac" {
+		t.Fatalf("unexpected agent id: %q", cfg.AgentID)
+	}
+
+	stdout.Reset()
+	if err := run([]string{"show", "--config", path}, &stdout, &stdout); err != nil {
+		t.Fatalf("run show with explicit config: %v", err)
+	}
+	if !strings.Contains(stdout.String(), path) {
+		t.Fatalf("expected show output to mention explicit path, got %q", stdout.String())
+	}
+}
+
+func readFile(t *testing.T, path string) []byte {
+	t.Helper()
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read file %s: %v", path, err)
+	}
+	return raw
+}

--- a/docs/macos-launchd.md
+++ b/docs/macos-launchd.md
@@ -9,16 +9,17 @@ Template:
 Recommended layout:
 
 - binary: `~/.local/bin/gotunnel`
-- config: `~/.config/gotunnel/<name>.json`
+- config: `~/.gotunnel/agent.json`
 - plist: `~/Library/LaunchAgents/io.github.grepug.gotunnel.<name>.plist`
 - logs: `~/Library/Logs/gotunnel/<name>.out.log` and `~/Library/Logs/gotunnel/<name>.err.log`
 
 ## Basic Flow
 
-1. Copy the plist template.
-2. Replace the user path, config path, label suffix, and log paths.
-3. Load it with `launchctl bootstrap`.
-4. Use `launchctl print` and the log files for status.
+1. Initialize and populate `~/.gotunnel/agent.json` first with `gotunnel init`, `gotunnel set ...`, and `gotunnel target add ...`.
+2. Copy the plist template.
+3. Replace the user path, label suffix, and log paths if needed.
+4. Load it with `launchctl bootstrap`.
+5. Use `launchctl print` and the log files for status.
 
 Example commands:
 
@@ -59,3 +60,4 @@ launchctl bootout "gui/$(id -u)" ~/Library/LaunchAgents/io.github.grepug.gotunne
 ```
 
 If you only need one-off testing, you do not need `launchd`. Running `./gotunnel -config /path/to/agent.json` in a shell is enough.
+If you use the default config home, `./gotunnel run` is enough.

--- a/docs/superpowers/specs/2026-04-21-agent-cli-design.md
+++ b/docs/superpowers/specs/2026-04-21-agent-cli-design.md
@@ -1,0 +1,125 @@
+# gotunnel Agent CLI Design
+
+## Goal
+
+Replace manual agent JSON editing as the normal user workflow with a small built-in CLI.
+
+## Scope
+
+This slice is agent-side only.
+
+It adds:
+
+- a default config home at `~/.gotunnel/agent.json`
+- commands to initialize, inspect, and update agent config
+- a CLI-first README path
+
+It does not add:
+
+- relay management
+- remote APIs
+- dynamic provisioning
+- config schema changes
+
+## Supported workflow
+
+Normal user flow:
+
+1. `gotunnel init`
+2. `gotunnel set relay --url ...`
+3. `gotunnel set auth --agent-id ... --auth-token ...`
+4. `gotunnel target add --name ssh --local-addr 127.0.0.1:22`
+5. `gotunnel show`
+6. `gotunnel run`
+
+Compatibility flow:
+
+- `gotunnel -config /path/to/agent.json`
+- `gotunnel run -config /path/to/agent.json`
+
+## Design
+
+### Config storage
+
+Keep `config.AgentConfig` as the only agent config schema.
+
+Add helpers in `internal/config` to:
+
+- resolve `~/.gotunnel/agent.json`
+- load from that path
+- save JSON to that path
+- load/save explicit paths when `-config` is supplied
+
+The CLI should create `~/.gotunnel` on first write.
+
+### Command structure
+
+Use standard-library argument parsing in `cmd/gotunnel`.
+
+Commands:
+
+- `init`
+- `set relay`
+- `set auth`
+- `target add`
+- `show`
+- `run`
+
+The old top-level `-config` invocation remains a compatibility shortcut for `run`.
+
+### Mutations
+
+`init`:
+
+- writes a minimal config file if missing
+- leaves an existing file intact unless an explicit overwrite flag is added later
+
+`set relay`:
+
+- updates `relay_url`
+
+`set auth`:
+
+- updates `agent_id`
+- updates `auth_token`
+
+`target add`:
+
+- upserts by target name
+- validates `local_addr`
+
+### Output
+
+`show` should print:
+
+- config path
+- relay URL
+- agent ID
+- targets as `name -> local_addr`
+
+Mutating commands should print the config path they wrote.
+
+### Backward compatibility
+
+Manual JSON config files stay valid.
+
+The runtime path still goes through:
+
+- `config.LoadAgentConfig`
+- `agent.NewClient`
+- `client.Start`
+
+## Testing
+
+Add tests before implementation for:
+
+- default config path resolution
+- saving and loading default config
+- CLI mutation commands
+- compatibility `-config` run parsing
+
+## Risks
+
+- command parsing can sprawl if it tries to manage too many workflows
+- CLI-generated config must not diverge from manual JSON config
+- `run` must fail clearly when config is incomplete

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -23,7 +23,7 @@ If the local service is not healthy, the relay cannot fix that.
 Run the agent in the foreground first if needed:
 
 ```bash
-./gotunnel -config /path/to/agent.json
+./gotunnel run
 ```
 
 On macOS with `launchd`, inspect the service:
@@ -38,6 +38,7 @@ Common causes:
 - wrong `agent_id`
 - wrong `relay_url`
 - local target port is not listening
+- the stored config in `~/.gotunnel/agent.json` does not match what the relay operator assigned
 
 ## Check The Relay
 

--- a/examples/gotunnel.agent.plist.example
+++ b/examples/gotunnel.agent.plist.example
@@ -8,8 +8,7 @@
 	<key>ProgramArguments</key>
 	<array>
 		<string>/Users/your-user/.local/bin/gotunnel</string>
-		<string>-config</string>
-		<string>/Users/your-user/.config/gotunnel/example.json</string>
+		<string>run</string>
 	</array>
 
 	<key>RunAtLoad</key>

--- a/internal/config/home_test.go
+++ b/internal/config/home_test.go
@@ -1,0 +1,63 @@
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gotunnel/internal/config"
+)
+
+func TestDefaultAgentConfigPathUsesHomeGotunnelDirectory(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	path, err := config.DefaultAgentConfigPath()
+	if err != nil {
+		t.Fatalf("default agent config path: %v", err)
+	}
+
+	want := filepath.Join(home, ".gotunnel", "agent.json")
+	if path != want {
+		t.Fatalf("unexpected default agent config path: got %q want %q", path, want)
+	}
+}
+
+func TestSaveAndLoadDefaultAgentConfigRoundTrips(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cfg := config.AgentConfig{
+		RelayURL:      "ws://127.0.0.1:18443/connect",
+		AgentID:       "home-mac",
+		AuthToken:     "secret",
+		AllowInsecure: true,
+		Targets: []config.TargetMapping{
+			{Name: "ssh", LocalAddr: "127.0.0.1:22"},
+		},
+	}
+
+	path, err := config.SaveDefaultAgentConfig(cfg)
+	if err != nil {
+		t.Fatalf("save default agent config: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Dir(path)); err != nil {
+		t.Fatalf("stat config dir: %v", err)
+	}
+
+	loaded, err := config.LoadDefaultAgentConfig()
+	if err != nil {
+		t.Fatalf("load default agent config: %v", err)
+	}
+
+	if loaded.AgentID != cfg.AgentID {
+		t.Fatalf("unexpected agent id: got %q want %q", loaded.AgentID, cfg.AgentID)
+	}
+	if loaded.RelayURL != cfg.RelayURL {
+		t.Fatalf("unexpected relay url: got %q want %q", loaded.RelayURL, cfg.RelayURL)
+	}
+	if len(loaded.Targets) != 1 || loaded.Targets[0].Name != "ssh" {
+		t.Fatalf("unexpected targets: %+v", loaded.Targets)
+	}
+}

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -2,8 +2,10 @@ package config
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 )
 
 func LoadRelayConfig(path string) (RelayConfig, error) {
@@ -37,6 +39,60 @@ func LoadAgentConfig(path string) (AgentConfig, error) {
 		return AgentConfig{}, err
 	}
 	return cfg, nil
+}
+
+func LoadAgentDraftConfig(path string) (AgentConfig, error) {
+	var cfg AgentConfig
+	if err := loadJSON(path, &cfg); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return AgentConfig{}, nil
+		}
+		return AgentConfig{}, err
+	}
+	return cfg, nil
+}
+
+func DefaultAgentConfigPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve user home: %w", err)
+	}
+	return filepath.Join(home, ".gotunnel", "agent.json"), nil
+}
+
+func LoadDefaultAgentConfig() (AgentConfig, error) {
+	path, err := DefaultAgentConfigPath()
+	if err != nil {
+		return AgentConfig{}, err
+	}
+	return LoadAgentConfig(path)
+}
+
+func SaveDefaultAgentConfig(cfg AgentConfig) (string, error) {
+	path, err := DefaultAgentConfigPath()
+	if err != nil {
+		return "", err
+	}
+	if err := SaveAgentConfig(path, cfg); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+func SaveAgentConfig(path string, cfg AgentConfig) error {
+	raw, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode config %s: %w", path, err)
+	}
+	raw = append(raw, '\n')
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create config dir %s: %w", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		return fmt.Errorf("write config %s: %w", path, err)
+	}
+	return nil
 }
 
 func loadJSON(path string, dst any) error {


### PR DESCRIPTION
## Summary

- Add a CLI-first gotunnel agent workflow with init/set/target/show/run commands and a default ~/.gotunnel config home
- Keep legacy -config compatibility while updating README and macOS docs to teach the new host-machine workflow

## Linked Issue

Closes #17

## Closeout Checklist

- [x] Re-read the linked issue after implementation
- [x] Reconciled the canonical plan comment checklist against the shipped code
- [x] No unchecked implementation checklist items remain in the issue body or canonical plan comment
- [x] This PR inherits the linked issue milestone when one exists

## Checklist Audit

- Issue body unchecked items: 0
- Canonical plan comment blocking unchecked items: 0
- Canonical plan comment non-blocking unchecked items: 0
- Canonical plan comment: https://github.com/grepug/gotunnel/issues/17#issuecomment-4289806742

## Validation

- go test ./...
- go build ./cmd/gotunnel ./cmd/gotunneld
