### PR TITLE
feature: ship Ubuntu relay bootstrap assets for the supported v1 operator path

### DIFF
--- a/docs/relay-setup.md
+++ b/docs/relay-setup.md
@@ -4,6 +4,8 @@ This guide is for the person who runs the VPS relay.
 
 If you only need to connect a local machine to an existing relay, go back to the [main README](../README.md) and use the agent quick start there.
 
+If you want the first supported end-to-end operator path, start with [ubuntu-relay-bootstrap.md](ubuntu-relay-bootstrap.md).
+
 ## What The Relay Operator Owns
 
 The relay operator manages:
@@ -22,6 +24,22 @@ Automatic TLS and certificate management are not built into `gotunnel` yet. If y
 ```bash
 go build ./cmd/gotunnel ./cmd/gotunneld
 ```
+
+## Supported Bootstrap Path
+
+For `v1`, the first supported operator path is:
+
+- one public Ubuntu LTS VPS
+- `systemd`
+- direct `gotunneld` TLS termination
+- Certbot-managed short-lived IP certificates
+
+Use:
+
+- [ubuntu-relay-bootstrap.md](ubuntu-relay-bootstrap.md)
+- [../examples/relay.ubuntu-ip.json](../examples/relay.ubuntu-ip.json)
+- [../examples/gotunneld.service.example](../examples/gotunneld.service.example)
+- [../scripts/bootstrap-relay-ubuntu.sh](../scripts/bootstrap-relay-ubuntu.sh)
 
 ## Relay Config
 

--- a/docs/ubuntu-relay-bootstrap.md
+++ b/docs/ubuntu-relay-bootstrap.md
@@ -1,0 +1,155 @@
+# Ubuntu Relay Bootstrap
+
+This guide is the first supported relay-operator path for `gotunnel v1`.
+
+Supported scope:
+
+- one public Ubuntu LTS VPS
+- `systemd` for service management
+- direct `gotunneld` TLS termination
+- Certbot-managed short-lived IP certificates
+- one relay binary at `/opt/gotunnel/gotunneld`
+- one relay config at `/etc/gotunnel/relay.json`
+- one relay state file at `/var/lib/gotunnel/relay-state.json`
+
+Out of scope for this guide:
+
+- domain-based TLS variants
+- reverse-proxy-managed TLS
+- non-`systemd` Linux setups
+- multi-node relay topologies
+
+## What You Need
+
+Before you start, have:
+
+- a public Ubuntu VPS
+- root or sudo access
+- a built `gotunneld` binary available locally or on the host
+- the public IP you want to use for the relay
+- at least one `agent_id` and `auth_token` pair for the first local machine
+
+## Repo Assets
+
+This repo now ships the supported bootstrap assets:
+
+- bootstrap helper: [../scripts/bootstrap-relay-ubuntu.sh](../scripts/bootstrap-relay-ubuntu.sh)
+- supported relay config template: [../examples/relay.ubuntu-ip.json](../examples/relay.ubuntu-ip.json)
+- `systemd` unit example: [../examples/gotunneld.service.example](../examples/gotunneld.service.example)
+
+## Fastest Path
+
+If you already have a `gotunneld` binary on the Ubuntu host, run the helper script there:
+
+```bash
+sudo bash ./scripts/bootstrap-relay-ubuntu.sh \
+  --binary ./gotunneld \
+  --ip 203.0.113.10 \
+  --agent-id home-mac \
+  --auth-token replace-me-home-mac
+```
+
+That script does three things:
+
+1. installs the relay binary to `/opt/gotunnel/gotunneld`
+2. writes `/etc/gotunnel/relay.json`
+3. installs `/etc/systemd/system/gotunneld.service`
+
+It does not request certificates for you. Instead, it prints the exact Certbot issuance and renewal commands for the supported path.
+
+## Installed Layout
+
+After the helper runs, the supported layout is:
+
+- binary: `/opt/gotunnel/gotunneld`
+- config: `/etc/gotunnel/relay.json`
+- state: `/var/lib/gotunnel/relay-state.json`
+- systemd unit: `/etc/systemd/system/gotunneld.service`
+- TLS cert: `/etc/letsencrypt/live/<relay-ip>/fullchain.pem`
+- TLS key: `/etc/letsencrypt/live/<relay-ip>/privkey.pem`
+
+## Certificate Issuance
+
+For the supported path, use Certbot standalone with a short-lived IP certificate.
+
+Example:
+
+```bash
+sudo certbot certonly \
+  --standalone \
+  --non-interactive \
+  --agree-tos \
+  --register-unsafely-without-email \
+  --preferred-profile shortlived \
+  --ip-address 203.0.113.10
+```
+
+Important constraint:
+
+- Certbot standalone must be able to claim port `80`
+
+If another process already uses port `80`, stop it first or add a deterministic pre/post-hook flow for renewal.
+
+## Renewal And Restart Contract
+
+The supported renewal contract is:
+
+1. Certbot renews the short-lived IP certificate.
+2. A Certbot deploy hook restarts `gotunneld`.
+3. If another process uses port `80`, a pre-hook frees it and a post-hook restores it.
+
+Example deploy hook:
+
+```bash
+#!/bin/sh
+systemctl restart gotunneld
+```
+
+Suggested path:
+
+```bash
+/etc/letsencrypt/renewal-hooks/deploy/gotunneld-restart.sh
+```
+
+The helper script prints the exact commands for creating this hook.
+
+## Start The Relay
+
+After certificate issuance, start and enable the service:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now gotunneld
+```
+
+Check status:
+
+```bash
+sudo systemctl status gotunneld
+```
+
+## Verify The Relay
+
+Inspect the config:
+
+```bash
+sudo cat /etc/gotunnel/relay.json
+```
+
+Inspect persisted registration state when needed:
+
+```bash
+sudo /opt/gotunnel/gotunneld -config /etc/gotunnel/relay.json -status
+```
+
+Then connect a local machine using the assigned:
+
+- `relay_url`
+- `agent_id`
+- `auth_token`
+
+## Related Docs
+
+- relay overview: [relay-setup.md](relay-setup.md)
+- troubleshooting: [troubleshooting.md](troubleshooting.md)
+- agent onboarding: [../README.md](../README.md)

--- a/examples/gotunneld.service.example
+++ b/examples/gotunneld.service.example
@@ -1,0 +1,16 @@
+[Unit]
+Description=gotunnel relay
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/opt/gotunnel/gotunneld -config /etc/gotunnel/relay.json
+WorkingDirectory=/opt/gotunnel
+Restart=always
+RestartSec=2
+User=root
+Group=root
+
+[Install]
+WantedBy=multi-user.target

--- a/examples/relay.ubuntu-ip.json
+++ b/examples/relay.ubuntu-ip.json
@@ -1,0 +1,32 @@
+{
+  "control_addr": "0.0.0.0:18443",
+  "agents": [
+    {
+      "agent_id": "home-mac",
+      "auth_token": "replace-me-home-mac"
+    }
+  ],
+  "state_file": "/var/lib/gotunnel/relay-state.json",
+  "tls_cert_file": "/etc/letsencrypt/live/203.0.113.10/fullchain.pem",
+  "tls_key_file": "/etc/letsencrypt/live/203.0.113.10/privkey.pem",
+  "ports": [
+    {
+      "name": "ssh",
+      "listen_addr": "0.0.0.0:2222",
+      "agent_id": "home-mac",
+      "target_name": "ssh"
+    },
+    {
+      "name": "web",
+      "listen_addr": "0.0.0.0:28080",
+      "agent_id": "home-mac",
+      "target_name": "web"
+    },
+    {
+      "name": "desktop",
+      "listen_addr": "0.0.0.0:3389",
+      "agent_id": "home-mac",
+      "target_name": "desktop"
+    }
+  ]
+}

--- a/scripts/bootstrap-relay-ubuntu.sh
+++ b/scripts/bootstrap-relay-ubuntu.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bootstrap-relay-ubuntu.sh --binary <path-to-gotunneld> --ip <public-ip> --agent-id <agent-id> --auth-token <auth-token>
+
+Optional flags:
+  --control-port <port>   Default: 18443
+  --ssh-port <port>       Default: 2222
+  --web-port <port>       Default: 28080
+  --desktop-port <port>   Default: 3389
+
+This helper supports one path only:
+  Ubuntu LTS + systemd + direct gotunneld TLS termination + Certbot short-lived IP certificates
+EOF
+}
+
+BINARY=""
+RELAY_IP=""
+AGENT_ID=""
+AUTH_TOKEN=""
+CONTROL_PORT="18443"
+SSH_PORT="2222"
+WEB_PORT="28080"
+DESKTOP_PORT="3389"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --binary)
+      BINARY="$2"
+      shift 2
+      ;;
+    --ip)
+      RELAY_IP="$2"
+      shift 2
+      ;;
+    --agent-id)
+      AGENT_ID="$2"
+      shift 2
+      ;;
+    --auth-token)
+      AUTH_TOKEN="$2"
+      shift 2
+      ;;
+    --control-port)
+      CONTROL_PORT="$2"
+      shift 2
+      ;;
+    --ssh-port)
+      SSH_PORT="$2"
+      shift 2
+      ;;
+    --web-port)
+      WEB_PORT="$2"
+      shift 2
+      ;;
+    --desktop-port)
+      DESKTOP_PORT="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$BINARY" || -z "$RELAY_IP" || -z "$AGENT_ID" || -z "$AUTH_TOKEN" ]]; then
+  usage >&2
+  exit 1
+fi
+
+if [[ "${EUID:-$(id -u)}" -ne 0 ]]; then
+  echo "This helper must run as root or through sudo." >&2
+  exit 1
+fi
+
+if [[ ! -f "$BINARY" ]]; then
+  echo "Binary not found: $BINARY" >&2
+  exit 1
+fi
+
+BIN_DST="/opt/gotunnel/gotunneld"
+CFG_DIR="/etc/gotunnel"
+CFG_DST="${CFG_DIR}/relay.json"
+STATE_DIR="/var/lib/gotunnel"
+STATE_FILE="${STATE_DIR}/relay-state.json"
+UNIT_DST="/etc/systemd/system/gotunneld.service"
+CERT_DIR="/etc/letsencrypt/live/${RELAY_IP}"
+
+install -d -m 0755 /opt/gotunnel
+install -d -m 0755 "${CFG_DIR}"
+install -d -m 0755 "${STATE_DIR}"
+
+install -m 0755 "$BINARY" "$BIN_DST"
+
+cat > "$CFG_DST" <<EOF
+{
+  "control_addr": "0.0.0.0:${CONTROL_PORT}",
+  "agents": [
+    {
+      "agent_id": "${AGENT_ID}",
+      "auth_token": "${AUTH_TOKEN}"
+    }
+  ],
+  "state_file": "${STATE_FILE}",
+  "tls_cert_file": "${CERT_DIR}/fullchain.pem",
+  "tls_key_file": "${CERT_DIR}/privkey.pem",
+  "ports": [
+    {
+      "name": "ssh",
+      "listen_addr": "0.0.0.0:${SSH_PORT}",
+      "agent_id": "${AGENT_ID}",
+      "target_name": "ssh"
+    },
+    {
+      "name": "web",
+      "listen_addr": "0.0.0.0:${WEB_PORT}",
+      "agent_id": "${AGENT_ID}",
+      "target_name": "web"
+    },
+    {
+      "name": "desktop",
+      "listen_addr": "0.0.0.0:${DESKTOP_PORT}",
+      "agent_id": "${AGENT_ID}",
+      "target_name": "desktop"
+    }
+  ]
+}
+EOF
+
+cat > "$UNIT_DST" <<'EOF'
+[Unit]
+Description=gotunnel relay
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/opt/gotunnel/gotunneld -config /etc/gotunnel/relay.json
+WorkingDirectory=/opt/gotunnel
+Restart=always
+RestartSec=2
+User=root
+Group=root
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+echo
+echo "Installed supported relay bootstrap assets:"
+echo "  binary: ${BIN_DST}"
+echo "  config: ${CFG_DST}"
+echo "  state: ${STATE_FILE}"
+echo "  unit:   ${UNIT_DST}"
+echo
+echo "Next: request the short-lived IP certificate with Certbot standalone."
+echo
+cat <<EOF
+sudo certbot certonly \\
+  --standalone \\
+  --non-interactive \\
+  --agree-tos \\
+  --register-unsafely-without-email \\
+  --preferred-profile shortlived \\
+  --ip-address ${RELAY_IP}
+EOF
+echo
+echo "Important:"
+echo "  Certbot standalone must be able to claim port 80 during issuance and renewal."
+echo "  If another process already uses port 80, stop it first or use a deterministic pre/post-hook flow."
+echo
+echo "Suggested deploy hook:"
+echo
+cat <<'EOF'
+sudo install -d -m 0755 /etc/letsencrypt/renewal-hooks/deploy
+sudo tee /etc/letsencrypt/renewal-hooks/deploy/gotunneld-restart.sh >/dev/null <<'HOOK'
+#!/bin/sh
+systemctl restart gotunneld
+HOOK
+sudo chmod 0755 /etc/letsencrypt/renewal-hooks/deploy/gotunneld-restart.sh
+EOF
+echo
+echo "After certificate issuance:"
+echo
+cat <<'EOF'
+sudo systemctl daemon-reload
+sudo systemctl enable --now gotunneld
+sudo systemctl status gotunneld
+EOF


### PR DESCRIPTION
## Summary

- Add the supported Ubuntu relay bootstrap guide, systemd unit example, relay config template, and helper script
- Link the supported operator path from relay docs and validate the script plus repo consistency

## Linked Issue

Closes #21

## Closeout Checklist

- [x] Re-read the linked issue after implementation
- [x] Reconciled the canonical plan comment checklist against the shipped code
- [x] No unchecked implementation checklist items remain in the issue body or canonical plan comment
- [x] This PR inherits the linked issue milestone when one exists

## Checklist Audit

- Issue body unchecked items: 0
- Canonical plan comment blocking unchecked items: 0
- Canonical plan comment non-blocking unchecked items: 0
- Canonical plan comment: https://github.com/grepug/gotunnel/issues/21#issuecomment-4292941729

## Validation

- bash -n scripts/bootstrap-relay-ubuntu.sh
- go test ./...
- go build ./cmd/gotunnel ./cmd/gotunneld
