### PR TITLE
feature: add persisted relay route registrations and gotunneld admin commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ Before the local machine does anything, the relay operator or VPS owner should a
 - your assigned `agent_id`
 - your assigned `auth_token`
 
+On the VPS side, that public port can still be assigned either:
+
+- in static relay config under `ports`
+- or with the local relay-admin command `gotunneld routes create`
+
 ### Host Machine Side
 
 ### 1. Initialize local config
@@ -165,6 +170,7 @@ If you run the VPS side, start here:
 The operator guide covers:
 
 - relay config and public port mappings
+- local public-route management with `gotunneld routes`
 - TLS and certificate handling for `wss://`
 - relay status inspection with `gotunneld -status`
 - where `state_file` fits

--- a/cmd/gotunneld/main.go
+++ b/cmd/gotunneld/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -16,42 +17,162 @@ import (
 )
 
 func main() {
-	configPath := flag.String("config", "", "Path to relay JSON config")
-	statusMode := flag.Bool("status", false, "Print persisted relay registration status and exit")
-	flag.Parse()
+	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
+}
+
+func run(args []string, stdout, stderr io.Writer) int {
+	flags := flag.NewFlagSet("gotunneld", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+
+	configPath := flags.String("config", "", "Path to relay JSON config")
+	statusMode := flags.Bool("status", false, "Print persisted relay registration status and exit")
+	if err := flags.Parse(args); err != nil {
+		return 2
+	}
 
 	if *configPath == "" {
-		fmt.Fprintln(os.Stderr, "-config is required")
-		os.Exit(2)
+		fmt.Fprintln(stderr, "-config is required")
+		return 2
+	}
+
+	remaining := flags.Args()
+	if *statusMode && len(remaining) > 0 {
+		fmt.Fprintln(stderr, "-status cannot be combined with subcommands")
+		return 2
+	}
+	if len(remaining) > 0 {
+		return runSubcommand(*configPath, remaining, stdout, stderr)
 	}
 
 	cfg, err := loadRelayConfig(*configPath, *statusMode)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "load relay config: %v\n", err)
-		os.Exit(1)
+		fmt.Fprintf(stderr, "load relay config: %v\n", err)
+		return 1
 	}
 
 	if *statusMode {
-		if err := renderStatusReport(os.Stdout, cfg); err != nil {
-			fmt.Fprintf(os.Stderr, "render relay status: %v\n", err)
-			os.Exit(1)
+		if err := renderStatusReport(stdout, cfg); err != nil {
+			fmt.Fprintf(stderr, "render relay status: %v\n", err)
+			return 1
 		}
-		return
+		return 0
 	}
 
 	server, err := relay.NewServer(cfg)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "create relay server: %v\n", err)
-		os.Exit(1)
+		fmt.Fprintf(stderr, "create relay server: %v\n", err)
+		return 1
 	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
 	if err := server.Start(ctx); err != nil {
-		fmt.Fprintf(os.Stderr, "run relay server: %v\n", err)
-		os.Exit(1)
+		fmt.Fprintf(stderr, "run relay server: %v\n", err)
+		return 1
 	}
+	return 0
+}
+
+func runSubcommand(configPath string, args []string, stdout, stderr io.Writer) int {
+	switch args[0] {
+	case "routes":
+		return runRoutesCommand(configPath, args[1:], stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "unknown subcommand: %s\n", args[0])
+		return 2
+	}
+}
+
+func runRoutesCommand(configPath string, args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		fmt.Fprintln(stderr, "routes subcommand is required: create, list, or remove")
+		return 2
+	}
+
+	cfg, err := loadRouteAdminConfig(configPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "load relay config: %v\n", err)
+		return 1
+	}
+
+	switch args[0] {
+	case "list":
+		if err := renderRouteRegistrations(stdout, cfg); err != nil {
+			fmt.Fprintf(stderr, "list routes: %v\n", err)
+			return 1
+		}
+		return 0
+	case "create":
+		return runRoutesCreate(cfg, args[1:], stdout, stderr)
+	case "remove":
+		return runRoutesRemove(cfg, args[1:], stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "unknown routes subcommand: %s\n", args[0])
+		return 2
+	}
+}
+
+func runRoutesCreate(cfg config.RelayConfig, args []string, stdout, stderr io.Writer) int {
+	flags := flag.NewFlagSet("gotunneld routes create", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+
+	name := flags.String("name", "", "Unique public route name")
+	listenAddr := flags.String("listen", "", "Public listen address")
+	agentID := flags.String("agent", "", "Destination agent ID")
+	targetName := flags.String("target", "", "Destination target name")
+	if err := flags.Parse(args); err != nil {
+		return 2
+	}
+	if len(flags.Args()) != 0 {
+		fmt.Fprintf(stderr, "unexpected arguments for routes create: %s\n", strings.Join(flags.Args(), " "))
+		return 2
+	}
+
+	err := relay.CreateRouteRegistration(cfg.StateFile, cfg.Agents, cfg.Ports, relay.RouteRegistration{
+		RouteName:  *name,
+		ListenAddr: *listenAddr,
+		AgentID:    *agentID,
+		TargetName: *targetName,
+	})
+	if err != nil {
+		fmt.Fprintf(stderr, "create route: %v\n", err)
+		return 1
+	}
+
+	fmt.Fprintf(stdout, "created route %s\n", *name)
+	return 0
+}
+
+func runRoutesRemove(cfg config.RelayConfig, args []string, stdout, stderr io.Writer) int {
+	flags := flag.NewFlagSet("gotunneld routes remove", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+
+	name := flags.String("name", "", "Public route name")
+	if err := flags.Parse(args); err != nil {
+		return 2
+	}
+	if len(flags.Args()) != 0 {
+		fmt.Fprintf(stderr, "unexpected arguments for routes remove: %s\n", strings.Join(flags.Args(), " "))
+		return 2
+	}
+	if *name == "" {
+		fmt.Fprintln(stderr, "remove route: name is required")
+		return 2
+	}
+
+	removed, err := relay.RemoveRouteRegistration(cfg.StateFile, *name)
+	if err != nil {
+		fmt.Fprintf(stderr, "remove route: %v\n", err)
+		return 1
+	}
+	if !removed {
+		fmt.Fprintf(stderr, "remove route: route %s does not exist\n", *name)
+		return 1
+	}
+
+	fmt.Fprintf(stdout, "removed route %s\n", *name)
+	return 0
 }
 
 func loadRelayConfig(path string, statusMode bool) (config.RelayConfig, error) {
@@ -59,6 +180,17 @@ func loadRelayConfig(path string, statusMode bool) (config.RelayConfig, error) {
 		return config.LoadRelayStatusConfig(path)
 	}
 	return config.LoadRelayConfig(path)
+}
+
+func loadRouteAdminConfig(path string) (config.RelayConfig, error) {
+	cfg, err := config.LoadRelayStatusConfig(path)
+	if err != nil {
+		return config.RelayConfig{}, err
+	}
+	if cfg.StateFile == "" {
+		return config.RelayConfig{}, errors.New("state_file is required for routes commands")
+	}
+	return cfg, nil
 }
 
 func renderStatusReport(w io.Writer, cfg config.RelayConfig) error {
@@ -89,6 +221,20 @@ func renderStatusReport(w io.Writer, cfg config.RelayConfig) error {
 			lastConnected,
 			lastDisconnected,
 		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func renderRouteRegistrations(w io.Writer, cfg config.RelayConfig) error {
+	routes, err := relay.LoadRouteRegistrations(cfg.StateFile)
+	if err != nil {
+		return err
+	}
+
+	for _, route := range routes {
+		if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", route.RouteName, route.ListenAddr, route.AgentID, route.TargetName); err != nil {
 			return err
 		}
 	}

--- a/cmd/gotunneld/main_test.go
+++ b/cmd/gotunneld/main_test.go
@@ -135,3 +135,86 @@ func TestLoadRelayConfigRequiresFullValidationOutsideStatusMode(t *testing.T) {
 		t.Fatal("expected full relay validation to fail without runtime fields")
 	}
 }
+
+func TestRunRoutesLifecycle(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "relay.json")
+	statePath := filepath.Join(t.TempDir(), "relay-state.json")
+	content := `{
+		"agents": [
+			{"agent_id": "home-mac", "auth_token": "secret"}
+		],
+		"state_file": "` + statePath + `"
+	}`
+	if err := os.WriteFile(configPath, []byte(content), 0o600); err != nil {
+		t.Fatalf("write relay config: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := run([]string{
+		"-config", configPath,
+		"routes", "create",
+		"--name", "ssh",
+		"--listen", "127.0.0.1:2222",
+		"--agent", "home-mac",
+		"--target", "ssh",
+	}, &stdout, &stderr)
+	if exitCode != 0 {
+		t.Fatalf("create route exit code = %d, stderr=%s", exitCode, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "created route ssh") {
+		t.Fatalf("unexpected create output: %s", stdout.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	exitCode = run([]string{
+		"-config", configPath,
+		"routes", "list",
+	}, &stdout, &stderr)
+	if exitCode != 0 {
+		t.Fatalf("list routes exit code = %d, stderr=%s", exitCode, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "ssh\t127.0.0.1:2222\thome-mac\tssh") {
+		t.Fatalf("unexpected list output: %s", stdout.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	exitCode = run([]string{
+		"-config", configPath,
+		"routes", "remove",
+		"--name", "ssh",
+	}, &stdout, &stderr)
+	if exitCode != 0 {
+		t.Fatalf("remove route exit code = %d, stderr=%s", exitCode, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "removed route ssh") {
+		t.Fatalf("unexpected remove output: %s", stdout.String())
+	}
+}
+
+func TestRunRoutesRequiresStateFile(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "relay.json")
+	content := `{
+		"agents": [
+			{"agent_id": "home-mac", "auth_token": "secret"}
+		]
+	}`
+	if err := os.WriteFile(configPath, []byte(content), 0o600); err != nil {
+		t.Fatalf("write relay config: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := run([]string{
+		"-config", configPath,
+		"routes", "list",
+	}, &stdout, &stderr)
+	if exitCode != 1 {
+		t.Fatalf("expected missing state_file to fail, exit code=%d stderr=%s", exitCode, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "state_file is required for routes commands") {
+		t.Fatalf("unexpected stderr: %s", stderr.String())
+	}
+}

--- a/docs/relay-setup.md
+++ b/docs/relay-setup.md
@@ -41,6 +41,17 @@ Use:
 - [../examples/gotunneld.service.example](../examples/gotunneld.service.example)
 - [../scripts/bootstrap-relay-ubuntu.sh](../scripts/bootstrap-relay-ubuntu.sh)
 
+## Public Route Management
+
+You now have two supported ways to assign public ports on the VPS:
+
+- keep using static `ports` in relay config
+- manage persisted public routes locally with `gotunneld routes`
+
+Static `ports` are still supported. Persisted routes are the newer operator workflow when you want to add or remove public route registrations without hand-editing the relay JSON file.
+
+If you use the `gotunneld routes` workflow, `state_file` is required because the relay stores those route registrations there.
+
 ## Relay Config
 
 Example:
@@ -90,7 +101,7 @@ Example relay config:
 - `agents`: relay-side credentials for each named agent
 - `agents[].agent_id`: the only agent name allowed to use that credential
 - `agents[].auth_token`: the shared secret for that agent
-- `state_file`: optional relay-local JSON file for persisted last-known registration state
+- `state_file`: optional relay-local JSON file for persisted last-known registration state; required if you want `gotunneld routes` to manage persisted public route registrations
 - `tls_cert_file`: certificate for the control connection
 - `tls_key_file`: private key for the control connection
 - `allow_insecure`: local testing only; allows plain `ws://`
@@ -103,6 +114,44 @@ Example relay config:
 ```bash
 ./gotunneld -config /path/to/relay.json
 ```
+
+If your relay config keeps public listeners in static `ports`, that is enough.
+
+If you use persisted public route registrations, create them first and then start or restart the relay so it opens the matching listeners.
+
+## Manage Persisted Public Routes
+
+Create a public route registration on the VPS:
+
+```bash
+./gotunneld -config /path/to/relay.json routes create \
+  --name ssh \
+  --listen 0.0.0.0:2222 \
+  --agent home-mac \
+  --target ssh
+```
+
+List persisted public route registrations:
+
+```bash
+./gotunneld -config /path/to/relay.json routes list
+```
+
+Example output shape:
+
+```text
+ssh	0.0.0.0:2222	home-mac	ssh
+web	0.0.0.0:28080	home-mac	web
+desktop	0.0.0.0:3389	home-mac	desktop
+```
+
+Remove a persisted public route registration:
+
+```bash
+./gotunneld -config /path/to/relay.json routes remove --name ssh
+```
+
+In this first slice, route changes are persisted locally but are not hot-reloaded into an already running relay process. After `routes create` or `routes remove`, restart `gotunneld` if the relay is already running.
 
 ## TLS Notes
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -55,8 +55,8 @@ func (c RelayConfig) Validate() error {
 	if !c.AllowInsecure && c.TLSCertFile == "" {
 		return errors.New("tls_cert_file and tls_key_file are required unless allow_insecure is true")
 	}
-	if len(c.Ports) == 0 {
-		return errors.New("at least one port mapping is required")
+	if len(c.Ports) == 0 && c.StateFile == "" {
+		return errors.New("at least one port mapping or state_file is required")
 	}
 
 	if err := c.validateAgentAuths(); err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -204,6 +204,19 @@ func TestRelayConfigValidateRejectsMissingAgents(t *testing.T) {
 	}
 }
 
+func TestRelayConfigValidateAcceptsStateFileWithoutStaticPorts(t *testing.T) {
+	cfg := config.RelayConfig{
+		ControlAddr:   "127.0.0.1:0",
+		Agents:        []config.AgentAuth{{AgentID: "mac-mini", AuthToken: "secret"}},
+		StateFile:     "/tmp/relay-state.json",
+		AllowInsecure: true,
+	}
+
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected persisted-route relay config to validate, got %v", err)
+	}
+}
+
 func TestRelayConfigValidateRejectsDuplicateAgentIDs(t *testing.T) {
 	cfg := config.RelayConfig{
 		ControlAddr: "127.0.0.1:0",

--- a/internal/relay/server.go
+++ b/internal/relay/server.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -29,6 +30,7 @@ const duplicateAgentErrorPrefix = "duplicate active agent id:"
 
 type Server struct {
 	cfg             config.RelayConfig
+	routes          []config.PortMapping
 	controlListener net.Listener
 	publicListeners map[string]net.Listener
 	publicRoutes    map[string]config.PortMapping
@@ -58,14 +60,25 @@ func NewServer(cfg config.RelayConfig) (*Server, error) {
 		return nil, err
 	}
 
+	stateStore, err := newRegistrationStore(cfg.StateFile, cfg.Agents)
+	if err != nil {
+		return nil, err
+	}
+
+	persistedRoutes := routeRegistrationsFromState(stateStore.state)
+	routes, err := resolvePublicRoutes(cfg, persistedRoutes)
+	if err != nil {
+		return nil, err
+	}
+
 	controlListener, err := net.Listen("tcp", cfg.ControlAddr)
 	if err != nil {
 		return nil, fmt.Errorf("listen control: %w", err)
 	}
 
-	publicListeners := make(map[string]net.Listener, len(cfg.Ports))
-	publicRoutes := make(map[string]config.PortMapping, len(cfg.Ports))
-	for _, mapping := range cfg.Ports {
+	publicListeners := make(map[string]net.Listener, len(routes))
+	publicRoutes := make(map[string]config.PortMapping, len(routes))
+	for _, mapping := range routes {
 		ln, err := net.Listen("tcp", mapping.ListenAddr)
 		if err != nil {
 			_ = controlListener.Close()
@@ -80,21 +93,13 @@ func NewServer(cfg config.RelayConfig) (*Server, error) {
 
 	s := &Server{
 		cfg:             cfg,
+		routes:          routes,
 		controlListener: controlListener,
 		publicListeners: publicListeners,
 		publicRoutes:    publicRoutes,
 		sessions:        make(map[string]*session),
+		stateStore:      stateStore,
 	}
-
-	stateStore, err := newRegistrationStore(cfg.StateFile, cfg.Agents)
-	if err != nil {
-		_ = controlListener.Close()
-		for _, open := range publicListeners {
-			_ = open.Close()
-		}
-		return nil, err
-	}
-	s.stateStore = stateStore
 
 	mux := http.NewServeMux()
 	mux.HandleFunc(controlPath, s.handleControl)
@@ -119,7 +124,7 @@ func (s *Server) Start(ctx context.Context) error {
 		s.closeSession()
 	}()
 
-	for _, mapping := range s.cfg.Ports {
+	for _, mapping := range s.routes {
 		ln := s.publicListeners[mapping.Name]
 		go s.acceptPublic(ctx, mapping.Name, ln)
 	}
@@ -493,4 +498,51 @@ func configureWebSocket(conn *websocket.Conn) {
 	conn.SetPongHandler(func(string) error {
 		return conn.SetReadDeadline(time.Now().Add(pongWait))
 	})
+}
+
+func resolvePublicRoutes(cfg config.RelayConfig, persistedRoutes []RouteRegistration) ([]config.PortMapping, error) {
+	effective := make(map[string]config.PortMapping, len(cfg.Ports)+len(persistedRoutes))
+	for _, port := range cfg.Ports {
+		effective[port.Name] = port
+	}
+	for _, route := range persistedRoutes {
+		effective[route.RouteName] = config.PortMapping{
+			Name:       route.RouteName,
+			ListenAddr: route.ListenAddr,
+			AgentID:    route.AgentID,
+			TargetName: route.TargetName,
+		}
+	}
+	if len(effective) == 0 {
+		return nil, errors.New("at least one public route is required")
+	}
+
+	names := make([]string, 0, len(effective))
+	for name := range effective {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	routes := make([]config.PortMapping, 0, len(names))
+	seenListenAddrs := make(map[string]string, len(names))
+	for _, name := range names {
+		route := effective[name]
+		if !isEphemeralListenAddr(route.ListenAddr) {
+			if other, ok := seenListenAddrs[route.ListenAddr]; ok {
+				return nil, fmt.Errorf("listen_addr %s conflicts between routes %s and %s", route.ListenAddr, other, route.Name)
+			}
+			seenListenAddrs[route.ListenAddr] = route.Name
+		}
+		routes = append(routes, route)
+	}
+
+	return routes, nil
+}
+
+func isEphemeralListenAddr(listenAddr string) bool {
+	addr, err := net.ResolveTCPAddr("tcp", listenAddr)
+	if err != nil {
+		return false
+	}
+	return addr.Port == 0
 }

--- a/internal/relay/state.go
+++ b/internal/relay/state.go
@@ -3,6 +3,8 @@ package relay
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"sort"
@@ -13,7 +15,7 @@ import (
 )
 
 const (
-	registrationStateVersion   = 1
+	registrationStateVersion   = 2
 	registrationStatusNever    = "never_connected"
 	registrationStatusActive   = "active"
 	registrationStatusInactive = "inactive"
@@ -29,6 +31,7 @@ type registrationStore struct {
 type persistedRelayState struct {
 	Version int                             `json:"version"`
 	Agents  map[string]persistedAgentRecord `json:"agents"`
+	Routes  map[string]persistedRouteRecord `json:"routes,omitempty"`
 }
 
 type persistedAgentRecord struct {
@@ -40,6 +43,13 @@ type persistedAgentRecord struct {
 	UpdatedAt          time.Time `json:"updated_at"`
 }
 
+type persistedRouteRecord struct {
+	RouteName  string `json:"route_name"`
+	ListenAddr string `json:"listen_addr"`
+	AgentID    string `json:"agent_id"`
+	TargetName string `json:"target_name"`
+}
+
 type AgentStatus struct {
 	AgentID            string
 	Status             string
@@ -47,6 +57,13 @@ type AgentStatus struct {
 	LastConnectedAt    time.Time
 	LastDisconnectedAt time.Time
 	UpdatedAt          time.Time
+}
+
+type RouteRegistration struct {
+	RouteName  string
+	ListenAddr string
+	AgentID    string
+	TargetName string
 }
 
 func LoadAgentStatuses(path string, agents []config.AgentAuth) ([]AgentStatus, error) {
@@ -103,6 +120,7 @@ func newRegistrationStore(path string, agents []config.AgentAuth) (*registration
 		state: persistedRelayState{
 			Version: registrationStateVersion,
 			Agents:  make(map[string]persistedAgentRecord),
+			Routes:  make(map[string]persistedRouteRecord),
 		},
 	}
 
@@ -149,6 +167,7 @@ func loadPersistedRelayState(path string) (persistedRelayState, error) {
 	state := persistedRelayState{
 		Version: registrationStateVersion,
 		Agents:  make(map[string]persistedAgentRecord),
+		Routes:  make(map[string]persistedRouteRecord),
 	}
 	if path == "" {
 		return state, nil
@@ -162,12 +181,88 @@ func loadPersistedRelayState(path string) (persistedRelayState, error) {
 		if state.Agents == nil {
 			state.Agents = make(map[string]persistedAgentRecord)
 		}
+		if state.Routes == nil {
+			state.Routes = make(map[string]persistedRouteRecord)
+		}
 		return state, nil
 	}
 	if errors.Is(err, os.ErrNotExist) {
 		return state, nil
 	}
 	return persistedRelayState{}, err
+}
+
+func LoadRouteRegistrations(path string) ([]RouteRegistration, error) {
+	state, err := loadPersistedRelayState(path)
+	if err != nil {
+		return nil, err
+	}
+
+	names := make([]string, 0, len(state.Routes))
+	for routeName := range state.Routes {
+		names = append(names, routeName)
+	}
+	sort.Strings(names)
+
+	routes := make([]RouteRegistration, 0, len(names))
+	for _, routeName := range names {
+		record := state.Routes[routeName]
+		if record.RouteName == "" {
+			record.RouteName = routeName
+		}
+		routes = append(routes, RouteRegistration{
+			RouteName:  record.RouteName,
+			ListenAddr: record.ListenAddr,
+			AgentID:    record.AgentID,
+			TargetName: record.TargetName,
+		})
+	}
+
+	return routes, nil
+}
+
+func CreateRouteRegistration(path string, agents []config.AgentAuth, staticPorts []config.PortMapping, route RouteRegistration) error {
+	state, err := loadPersistedRelayState(path)
+	if err != nil {
+		return err
+	}
+
+	if err := validateRouteRegistration(route, agents); err != nil {
+		return err
+	}
+
+	if _, ok := state.Routes[route.RouteName]; ok {
+		return fmt.Errorf("route_name already exists: %s", route.RouteName)
+	}
+
+	routes := routeRegistrationsFromState(state)
+	routes = append(routes, route)
+	if _, err := resolvePublicRoutes(config.RelayConfig{Ports: staticPorts}, routes); err != nil {
+		return err
+	}
+
+	state.Routes[route.RouteName] = persistedRouteRecord{
+		RouteName:  route.RouteName,
+		ListenAddr: route.ListenAddr,
+		AgentID:    route.AgentID,
+		TargetName: route.TargetName,
+	}
+	return savePersistedRelayState(path, state)
+}
+
+func RemoveRouteRegistration(path, routeName string) (bool, error) {
+	state, err := loadPersistedRelayState(path)
+	if err != nil {
+		return false, err
+	}
+	if _, ok := state.Routes[routeName]; !ok {
+		return false, nil
+	}
+	delete(state.Routes, routeName)
+	if err := savePersistedRelayState(path, state); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func (s *registrationStore) markActive(agentID string, targets map[string]struct{}) error {
@@ -211,21 +306,25 @@ func (s *registrationStore) markInactive(agentID string) error {
 }
 
 func (s *registrationStore) saveLocked() error {
-	if s.path == "" {
+	return savePersistedRelayState(s.path, s.state)
+}
+
+func savePersistedRelayState(path string, state persistedRelayState) error {
+	if path == "" {
 		return nil
 	}
 
-	s.state.Version = registrationStateVersion
-	raw, err := json.MarshalIndent(s.state, "", "  ")
+	state.Version = registrationStateVersion
+	raw, err := json.MarshalIndent(state, "", "  ")
 	if err != nil {
 		return err
 	}
 
-	if err := os.MkdirAll(filepath.Dir(s.path), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
 	}
 
-	tmpFile, err := os.CreateTemp(filepath.Dir(s.path), "gotunnel-state-*.json")
+	tmpFile, err := os.CreateTemp(filepath.Dir(path), "gotunnel-state-*.json")
 	if err != nil {
 		return err
 	}
@@ -239,9 +338,58 @@ func (s *registrationStore) saveLocked() error {
 		_ = os.Remove(tmpName)
 		return err
 	}
-	if err := os.Rename(tmpName, s.path); err != nil {
+	if err := os.Rename(tmpName, path); err != nil {
 		_ = os.Remove(tmpName)
 		return err
+	}
+	return nil
+}
+
+func routeRegistrationsFromState(state persistedRelayState) []RouteRegistration {
+	names := make([]string, 0, len(state.Routes))
+	for routeName := range state.Routes {
+		names = append(names, routeName)
+	}
+	sort.Strings(names)
+
+	routes := make([]RouteRegistration, 0, len(names))
+	for _, routeName := range names {
+		record := state.Routes[routeName]
+		if record.RouteName == "" {
+			record.RouteName = routeName
+		}
+		routes = append(routes, RouteRegistration{
+			RouteName:  record.RouteName,
+			ListenAddr: record.ListenAddr,
+			AgentID:    record.AgentID,
+			TargetName: record.TargetName,
+		})
+	}
+	return routes
+}
+
+func validateRouteRegistration(route RouteRegistration, agents []config.AgentAuth) error {
+	if route.RouteName == "" {
+		return errors.New("route_name is required")
+	}
+	if route.ListenAddr == "" {
+		return fmt.Errorf("listen_addr is required for route %s", route.RouteName)
+	}
+	if _, err := net.ResolveTCPAddr("tcp", route.ListenAddr); err != nil {
+		return fmt.Errorf("invalid listen_addr for route %s: %w", route.RouteName, err)
+	}
+	if route.AgentID == "" {
+		return fmt.Errorf("agent_id is required for route %s", route.RouteName)
+	}
+	knownAgents := make(map[string]struct{}, len(agents))
+	for _, agent := range agents {
+		knownAgents[agent.AgentID] = struct{}{}
+	}
+	if _, ok := knownAgents[route.AgentID]; !ok {
+		return fmt.Errorf("unknown agent_id %s for route %s", route.AgentID, route.RouteName)
+	}
+	if route.TargetName == "" {
+		return fmt.Errorf("target_name is required for route %s", route.RouteName)
 	}
 	return nil
 }

--- a/internal/relay/state_test.go
+++ b/internal/relay/state_test.go
@@ -1,0 +1,121 @@
+package relay
+
+import (
+	"strings"
+	"testing"
+
+	"gotunnel/internal/config"
+)
+
+func TestCreateLoadAndRemoveRouteRegistrations(t *testing.T) {
+	statePath := t.TempDir() + "/relay-state.json"
+	agents := []config.AgentAuth{
+		{AgentID: "home-mac", AuthToken: "secret"},
+	}
+
+	route := RouteRegistration{
+		RouteName:  "ssh",
+		ListenAddr: "127.0.0.1:2222",
+		AgentID:    "home-mac",
+		TargetName: "ssh",
+	}
+
+	if err := CreateRouteRegistration(statePath, agents, nil, route); err != nil {
+		t.Fatalf("create route registration: %v", err)
+	}
+
+	routes, err := LoadRouteRegistrations(statePath)
+	if err != nil {
+		t.Fatalf("load route registrations: %v", err)
+	}
+	if len(routes) != 1 {
+		t.Fatalf("expected one route registration, got %d", len(routes))
+	}
+	if routes[0] != route {
+		t.Fatalf("unexpected route registration: %+v", routes[0])
+	}
+
+	removed, err := RemoveRouteRegistration(statePath, "ssh")
+	if err != nil {
+		t.Fatalf("remove route registration: %v", err)
+	}
+	if !removed {
+		t.Fatal("expected route registration to be removed")
+	}
+
+	routes, err = LoadRouteRegistrations(statePath)
+	if err != nil {
+		t.Fatalf("load route registrations after remove: %v", err)
+	}
+	if len(routes) != 0 {
+		t.Fatalf("expected no route registrations after remove, got %d", len(routes))
+	}
+}
+
+func TestCreateRouteRegistrationRejectsEffectiveListenConflict(t *testing.T) {
+	statePath := t.TempDir() + "/relay-state.json"
+	agents := []config.AgentAuth{
+		{AgentID: "home-mac", AuthToken: "secret"},
+	}
+	staticPorts := []config.PortMapping{
+		{
+			Name:       "web",
+			ListenAddr: "127.0.0.1:28080",
+			AgentID:    "home-mac",
+			TargetName: "web",
+		},
+	}
+
+	err := CreateRouteRegistration(statePath, agents, staticPorts, RouteRegistration{
+		RouteName:  "desktop",
+		ListenAddr: "127.0.0.1:28080",
+		AgentID:    "home-mac",
+		TargetName: "desktop",
+	})
+	if err == nil {
+		t.Fatal("expected conflicting route registration to fail")
+	}
+	if !strings.Contains(err.Error(), "listen_addr") {
+		t.Fatalf("expected listen_addr conflict error, got %v", err)
+	}
+}
+
+func TestResolvePublicRoutesPrefersPersistedRoutesByName(t *testing.T) {
+	cfg := config.RelayConfig{
+		Ports: []config.PortMapping{
+			{
+				Name:       "ssh",
+				ListenAddr: "127.0.0.1:2222",
+				AgentID:    "home-mac",
+				TargetName: "ssh",
+			},
+			{
+				Name:       "web",
+				ListenAddr: "127.0.0.1:28080",
+				AgentID:    "home-mac",
+				TargetName: "web",
+			},
+		},
+	}
+
+	routes, err := resolvePublicRoutes(cfg, []RouteRegistration{
+		{
+			RouteName:  "ssh",
+			ListenAddr: "127.0.0.1:2200",
+			AgentID:    "office-pc",
+			TargetName: "ssh",
+		},
+	})
+	if err != nil {
+		t.Fatalf("resolve public routes: %v", err)
+	}
+	if len(routes) != 2 {
+		t.Fatalf("expected 2 effective routes, got %d", len(routes))
+	}
+	if routes[0].Name != "ssh" || routes[0].ListenAddr != "127.0.0.1:2200" || routes[0].AgentID != "office-pc" {
+		t.Fatalf("expected persisted ssh route to win, got %+v", routes[0])
+	}
+	if routes[1].Name != "web" || routes[1].ListenAddr != "127.0.0.1:28080" {
+		t.Fatalf("expected static web route to remain, got %+v", routes[1])
+	}
+}


### PR DESCRIPTION
## Summary

- add relay-owned persisted route registrations and validation helpers
- add gotunneld routes create/list/remove and keep -status behavior intact
- document the VPS-side persisted route workflow and static-port compatibility

## Linked Issue

Closes #24

## Closeout Checklist

- [x] Re-read the linked issue after implementation
- [x] Reconciled the canonical plan comment checklist against the shipped code
- [x] No unchecked implementation checklist items remain in the issue body or canonical plan comment
- [x] This PR inherits the linked issue milestone when one exists

## Checklist Audit

- Issue body unchecked items: 0
- Canonical plan comment blocking unchecked items: 0
- Canonical plan comment non-blocking unchecked items: 0
- Canonical plan comment: https://github.com/grepug/gotunnel/issues/24#issuecomment-4292993653

## Validation

- go test ./...
- manual go run ./cmd/gotunneld -config <temp-config> routes create/list/remove
